### PR TITLE
update(plugin): update key mappings in glance.nvim

### DIFF
--- a/lua/repo/DNLHC/glance-nvim/config.lua
+++ b/lua/repo/DNLHC/glance-nvim/config.lua
@@ -7,22 +7,26 @@ glance.setup({
     },
     mappings = {
         list = {
-            ["<C-s>"] = actions.jump_split,
+            ["<C-x>"] = actions.jump_split,
             ["s"] = false,
             ["<C-v>"] = actions.jump_vsplit,
             ["v"] = false,
             ["<C-t>"] = actions.jump_tab,
             ["t"] = false,
-            -- quit
-            ["Q"] = false,
+            ["<leader>,"] = actions.enter_win("preview"),
+            ["<leader>."] = actions.enter_win("preview"),
+            ["<leader>l"] = false,
         },
         preview = {
             -- quit
-            ["q"] = actions.close,
+            ["q"] = false,
             ["Q"] = false,
             -- navigation
             ["<Tab>"] = false,
             ["<S-Tab>"] = false,
+            ["<leader>,"] = actions.enter_win("list"),
+            ["<leader>."] = actions.enter_win("list"),
+            ["<leader>l"] = false,
         },
     },
 })


### PR DESCRIPTION
1. Update `<C-s>` (open in split) to `<C-x>`, to keep compatible with nvim-tree.
2. Update `<Leader>l` (go to preview/list window) to `<Leader>,`/`<Leader>.`, to keep compatible with nvim-tree/bufferline.
3. Remove `q`/`Q` (close) in preview window, to reduce key mapping conflicts.

Relate lin.nvim.dev PR: [#3](https://github.com/linrongbin16/lin.nvim.dev/pull/3).