### PR TITLE
optimize(illuminate): move illuminate init to config to reduce startup time

### DIFF
--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -294,8 +294,7 @@ return {
     {
         "RRethy/vim-illuminate",
         event = { VeryLazy, BufRead, BufNewFile },
-        init = lua_init("RRethy/vim-illuminate"),
-        config = vim_config("RRethy/vim-illuminate"),
+        config = lua_config("RRethy/vim-illuminate"),
     },
     {
         "NvChad/nvim-colorizer.lua",

--- a/lua/repo/RRethy/vim-illuminate/config.lua
+++ b/lua/repo/RRethy/vim-illuminate/config.lua
@@ -6,3 +6,11 @@ require("illuminate").configure({
     -- disable cursor word for big file
     large_file_cutoff = const.perf.file.maxsize,
 })
+
+-- Highlight color
+vim.cmd([[
+augroup vim_illuminate_augroup
+    autocmd!
+    autocmd VimEnter * hi illuminatedWord cterm=underline gui=underline
+augroup END
+]])


### PR DESCRIPTION
1. move illuminate `init` section to `config` to reduce it's startup time (~5ms).