### PR TITLE
feat(plugin): use lspformatter for better async code format

### DIFF
--- a/lua/cfg/lsp/setup.lua
+++ b/lua/cfg/lsp/setup.lua
@@ -33,16 +33,6 @@ local embeded_servers_setups = {
     tsserver = function()
         lspconfig["tsserver"].setup({
             on_attach = lsp_on_attach,
-            root_dir = function(fname)
-                -- disable tsserver when detect flow
-                return lspconfig.util.root_pattern("tsconfig.json")(fname)
-                    or not lspconfig.util.root_pattern(".flowconfig")(fname)
-                        and lspconfig.util.root_pattern(
-                            "package.json",
-                            "jsconfig.json",
-                            ".git"
-                        )(fname)
-            end,
         })
     end,
     -- clangd = function()

--- a/lua/cfg/lsp/setup.lua
+++ b/lua/cfg/lsp/setup.lua
@@ -19,7 +19,7 @@ local function lsp_on_attach(client, bufnr)
         require("nvim-navic").attach(client, bufnr)
     end
     -- async code format
-    require("lsp-format").on_attach(client)
+    require("lspformatter").on_attach(client, bufnr)
 end
 
 -- { mason's config

--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -503,9 +503,10 @@ return {
         lazy = true,
     },
     {
-        "lukas-reineke/lsp-format.nvim",
+        "linrongbin16/lspformatter.nvim",
         event = { VeryLazy, BufRead, BufNewFile },
-        config = lua_config("lukas-reineke/lsp-format.nvim"),
+        dependencies = "linrongbin16/logger.nvim",
+        config = lua_config("linrongbin16/lspformatter.nvim"),
     },
 
     -- ---- SPECIFIC LANGUAGE SUPPORT ----

--- a/lua/repo/linrongbin16/lsp-progress-nvim/config.lua
+++ b/lua/repo/linrongbin16/lsp-progress-nvim/config.lua
@@ -1,1 +1,1 @@
-require("lsp-progress").setup({ decay = 500 })
+require("lsp-progress").setup()

--- a/lua/repo/linrongbin16/lspformatter-nvim/config.lua
+++ b/lua/repo/linrongbin16/lspformatter-nvim/config.lua
@@ -1,0 +1,1 @@
+require("lspformatter").setup()

--- a/lua/repo/linrongbin16/lspformatter-nvim/config.lua
+++ b/lua/repo/linrongbin16/lspformatter-nvim/config.lua
@@ -1,1 +1,3 @@
-require("lspformatter").setup()
+require("lspformatter").setup({
+    null_ls_only = true,
+})


### PR DESCRIPTION
1. Switch from `lsp-formatter` to `lspformatter`, for better async code formatting.
2. Allow only `null-ls` code formatter.
3. Set `lsp-progress` decay back to default(1000).

Relate PR: [#5](https://github.com/linrongbin16/lin.nvim.dev/pull/5)