### PR TITLE
plugin: config gitgutter use gitsigns style signs

### DIFF
--- a/lua/repo/airblade/vim-gitgutter/keys.lua
+++ b/lua/repo/airblade/vim-gitgutter/keys.lua
@@ -5,13 +5,13 @@ local M = {
         "n",
         "]c",
         "<Plug>(GitGutterNextHunk)",
-        { desc = "Next git hunk" }
+        { desc = "Go to next git hunk" }
     ),
     map_lazy(
         "n",
         "[c",
         "<Plug>(GitGutterPrevHunk)",
-        { desc = "Previous git hunk" }
+        { desc = "Go to previous git hunk" }
     ),
 }
 

--- a/repo/airblade/vim-gitgutter/init.vim
+++ b/repo/airblade/vim-gitgutter/init.vim
@@ -21,4 +21,4 @@ let g:gitgutter_sign_modified = '┃'                 " '~', U+2503
 let g:gitgutter_sign_removed = '▁'                  " '_', U+2581
 let g:gitgutter_sign_removed_first_line = '▔'       " '‾', U+2594
 let g:gitgutter_sign_modified_removed = '┃'         " '~_', U+2503
-" let g:gitgutter_sign_removed_above_and_below = '_¯'
+let g:gitgutter_sign_removed_above_and_below = '▁'  " '_¯', U+2581

--- a/repo/airblade/vim-gitgutter/init.vim
+++ b/repo/airblade/vim-gitgutter/init.vim
@@ -15,7 +15,10 @@ endif
 let g:gitgutter_preview_win_floating = 1
 
 " gitsigns style signs
-let g:gitgutter_sign_added = '┃' " '+'
-let g:gitgutter_sign_modified = '┃' " '~'
-let g:gitgutter_sign_removed = '▁' " '_'
-let g:gitgutter_sign_removed_first_line = '▔' " '‾'
+" unicode symbols: https://symbl.cc/en/html-entities/
+let g:gitgutter_sign_added = '┃'                    " '+'
+let g:gitgutter_sign_modified = '┃'                 " '~'
+let g:gitgutter_sign_removed = '▁'                  " '_'
+let g:gitgutter_sign_removed_first_line = '▔'       " '‾'
+let g:gitgutter_sign_modified_removed = '≃'         " '~_', U+2243
+" let g:gitgutter_sign_removed_above_and_below = '_¯'

--- a/repo/airblade/vim-gitgutter/init.vim
+++ b/repo/airblade/vim-gitgutter/init.vim
@@ -13,3 +13,9 @@ endif
 
 " use float window for preview
 let g:gitgutter_preview_win_floating = 1
+
+" gitsigns style signs
+let g:gitgutter_sign_added = '┃' " '+'
+let g:gitgutter_sign_modified = '┃' " '~'
+let g:gitgutter_sign_removed = '▁' " '_'
+let g:gitgutter_sign_removed_first_line = '▔' " '‾'

--- a/repo/airblade/vim-gitgutter/init.vim
+++ b/repo/airblade/vim-gitgutter/init.vim
@@ -20,5 +20,5 @@ let g:gitgutter_sign_added = '┃'                    " '+'
 let g:gitgutter_sign_modified = '┃'                 " '~'
 let g:gitgutter_sign_removed = '▁'                  " '_'
 let g:gitgutter_sign_removed_first_line = '▔'       " '‾'
-let g:gitgutter_sign_modified_removed = '≃'         " '~_', U+2243
+" let g:gitgutter_sign_modified_removed = '~_'
 " let g:gitgutter_sign_removed_above_and_below = '_¯'

--- a/repo/airblade/vim-gitgutter/init.vim
+++ b/repo/airblade/vim-gitgutter/init.vim
@@ -16,9 +16,9 @@ let g:gitgutter_preview_win_floating = 1
 
 " gitsigns style signs
 " unicode symbols: https://symbl.cc/en/html-entities/
-let g:gitgutter_sign_added = '┃'                    " '+'
-let g:gitgutter_sign_modified = '┃'                 " '~'
-let g:gitgutter_sign_removed = '▁'                  " '_'
-let g:gitgutter_sign_removed_first_line = '▔'       " '‾'
-" let g:gitgutter_sign_modified_removed = '~_'
+let g:gitgutter_sign_added = '┃'                    " '+', U+2503
+let g:gitgutter_sign_modified = '┃'                 " '~', U+2503
+let g:gitgutter_sign_removed = '▁'                  " '_', U+2581
+let g:gitgutter_sign_removed_first_line = '▔'       " '‾', U+2594
+let g:gitgutter_sign_modified_removed = '┃'         " '~_', U+2503
 " let g:gitgutter_sign_removed_above_and_below = '_¯'


### PR DESCRIPTION
1. Config gitgutter use gitsigns style signs
2. Update key mappings descriptions
