### PR TITLE
plugin: use neo-tree for better performance

### DIFF
--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -329,11 +329,29 @@ return {
     -- ---- UI ----
 
     -- File explorer
+    -- {
+    --     "nvim-tree/nvim-tree.lua",
+    --     event = { VimEnter },
+    --     config = lua_config("nvim-tree/nvim-tree.lua"),
+    --     keys = lua_keys("nvim-tree/nvim-tree.lua"),
+    -- },
+    -- {
+    --     "ms-jpq/chadtree",
+    --     event = { VimEnter },
+    --     branch = "chad",
+    --     build = "python3 -m chadtree deps",
+    --     init = lua_init("ms-jpq/chadtree"),
+    -- },
     {
-        "nvim-tree/nvim-tree.lua",
+        "nvim-neo-tree/neo-tree.nvim",
         event = { VimEnter },
-        config = lua_config("nvim-tree/nvim-tree.lua"),
-        keys = lua_keys("nvim-tree/nvim-tree.lua"),
+        branch = "v2.x",
+        dependencies = {
+            "MunifTanjim/nui.nvim",
+        },
+        init = vim_init("nvim-neo-tree/neo-tree.nvim"),
+        config = lua_config("nvim-neo-tree/neo-tree.nvim"),
+        keys = lua_keys("nvim-neo-tree/neo-tree.nvim"),
     },
     -- Tabline
     {

--- a/lua/repo/ms-jpq/chadtree/init.lua
+++ b/lua/repo/ms-jpq/chadtree/init.lua
@@ -1,0 +1,40 @@
+local function get_view_width()
+    local rate = 0.25
+    local min_w = 25
+    local max_w = 80
+    local editor_w = vim.o.columns
+    local tree_w = math.floor(editor_w * rate)
+    tree_w = vim.fn.min({ max_w, tree_w })
+    tree_w = vim.fn.max({ min_w, tree_w })
+    return tree_w
+end
+
+local chadtree_settings = {
+    ["options.show_hidden"] = true,
+    ["ignore.name_exact"] = {},
+    ["view.width"] = get_view_width(),
+    ["keymap"] = {
+        -- adjust explorer width
+        ["bigger"] = { "<Leader>." },
+        ["smaller"] = { "<Leader>," },
+
+        -- refresh
+        ["refresh"] = { "R" },
+
+        -- open node
+        ["primary"] = { "<Enter>", "l", "o", "<2-leftmouse>" },
+        -- close node
+        ["collapse"] = { "h" },
+        ["secondary"] = {},
+
+        -- open in new tab, vsplit, split
+        ["tertiary"] = { "<C-t>" },
+        ["v_split"] = { "<C-v>" },
+        ["h_split"] = { "<C-x>" },
+
+        -- open in system
+        ["open_sys"] = { "s" },
+    },
+}
+
+vim.api.nvim_set_var("chadtree_settings", chadtree_settings)

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -25,7 +25,7 @@ require("neo-tree").setup({
             symbols = {
                 added = "", -- : nf-fa-plus \uf067
                 modified = "", -- : nf-fa-circle \uf111
-                deleted = "", -- nf-fa-times \uf00d
+                deleted = "", -- nf-fa-times \uf00d
                 renamed = "", -- nf-fa-arrow_right \uf061
                 -- Status type
                 untracked = "", -- nf-fa-star \uf005
@@ -52,11 +52,10 @@ require("neo-tree").setup({
                     },
                     { "clipboard", zindex = 10 },
                     {
-                        -- move this indicator to left side
                         "diagnostics",
                         errors_only = true,
                         zindex = 20,
-                        align = "left",
+                        align = "right",
                         hide_when_expanded = true,
                     },
                     {
@@ -85,8 +84,8 @@ require("neo-tree").setup({
                     },
                     { "clipboard", zindex = 10 },
                     { "bufnr", zindex = 10 },
-                    { "modified", zindex = 20, align = "left" }, -- move this indicator to left side
-                    { "diagnostics", zindex = 20, align = "left" }, -- move this indicator to left side
+                    { "modified", zindex = 20, align = "right" },
+                    { "diagnostics", zindex = 20, align = "right" },
                     { "git_status", zindex = 20, align = "right" },
                 },
             },
@@ -120,15 +119,14 @@ require("neo-tree").setup({
             ["<C-x>"] = "open_split",
             ["<C-v>"] = "open_vsplit",
             ["<C-t>"] = "open_tabnew",
+            ["S"] = "none",
+            ["s"] = "none",
+            ["t"] = "none",
 
             ["W"] = "close_all_nodes",
             ["E"] = "expand_all_nodes",
             ["z"] = "none",
             ["e"] = "none",
-
-            -- help
-            ["g?"] = "show_help",
-            ["?"] = "none",
         },
     },
     filesystem = {

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -52,12 +52,13 @@ require("neo-tree").setup({
                     },
                     { "clipboard", zindex = 10 },
                     {
+                        -- move this indicator to left side
                         "diagnostics",
                         errors_only = true,
                         zindex = 20,
                         align = "left",
                         hide_when_expanded = true,
-                    }, -- move this indicator to left side
+                    },
                     {
                         "git_status",
                         zindex = 20,
@@ -94,6 +95,9 @@ require("neo-tree").setup({
     window = {
         width = get_view_width(),
         mappings = {
+            -- open node
+            ["l"] = "open",
+            -- close node
             ["h"] = function(state)
                 local node = state.tree:get_node()
                 if node.type == "directory" and node:is_expanded() then
@@ -108,11 +112,11 @@ require("neo-tree").setup({
                     )
                 end
             end,
-            ["l"] = "open",
             ["C"] = "none",
             ["<space>"] = "none",
             ["w"] = "none",
 
+            -- open in split/vsplit/tab
             ["<C-x>"] = "open_split",
             ["<C-v>"] = "open_vsplit",
             ["<C-t>"] = "open_tabnew",
@@ -120,8 +124,11 @@ require("neo-tree").setup({
             ["W"] = "close_all_nodes",
             ["E"] = "expand_all_nodes",
             ["z"] = "none",
-
             ["e"] = "none",
+
+            -- help
+            ["g?"] = "show_help",
+            ["?"] = "none",
         },
     },
     filesystem = {
@@ -130,6 +137,11 @@ require("neo-tree").setup({
         },
         follow_current_file = true,
         use_libuv_file_watcher = true,
+        window = {
+            ["<C-]>"] = "set_root",
+            ["[c"] = "prev_git_modified",
+            ["]c"] = "next_git_modified",
+        },
     },
 })
 

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -108,14 +108,14 @@ require("neo-tree").setup({
                     )
                 end
             end,
-            ["C"] = "none",
             ["l"] = "open",
+            ["C"] = "none",
             ["<space>"] = "none",
             ["w"] = "none",
 
-            ["s"] = "open_split",
-            ["v"] = "open_vsplit",
-            ["t"] = "open_tabnew",
+            ["<C-x>"] = "open_split",
+            ["<C-v>"] = "open_vsplit",
+            ["<C-t>"] = "open_tabnew",
 
             ["W"] = "close_all_nodes",
             ["E"] = "expand_all_nodes",

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -1,5 +1,16 @@
 local const = require("cfg.const")
 
+local function get_view_width()
+    local rate = 0.25
+    local min_w = 25
+    local max_w = 80
+    local editor_w = vim.o.columns
+    local tree_w = math.floor(editor_w * rate)
+    tree_w = vim.fn.min({ max_w, tree_w })
+    tree_w = vim.fn.max({ min_w, tree_w })
+    return tree_w
+end
+
 require("neo-tree").setup({
     popup_border_style = const.ui.border,
     default_component_configs = {
@@ -81,6 +92,7 @@ require("neo-tree").setup({
         },
     },
     window = {
+        width = get_view_width(),
         mappings = {
             ["h"] = function(state)
                 local node = state.tree:get_node()

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -138,9 +138,11 @@ require("neo-tree").setup({
         follow_current_file = true,
         use_libuv_file_watcher = true,
         window = {
-            ["<C-]>"] = "set_root",
-            ["[c"] = "prev_git_modified",
-            ["]c"] = "next_git_modified",
+            mappings = {
+                ["<C-]>"] = "set_root",
+                ["[c"] = "prev_git_modified",
+                ["]c"] = "next_git_modified",
+            },
         },
     },
 })

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -25,7 +25,7 @@ require("neo-tree").setup({
             symbols = {
                 added = "", -- : nf-fa-plus \uf067
                 modified = "", -- : nf-fa-circle \uf111
-                deleted = "", -- nf-fa-times \uf00d
+                deleted = "", -- : nf-fa-times \uf00d
                 renamed = "", -- nf-fa-arrow_right \uf061
                 -- Status type
                 untracked = "", -- nf-fa-star \uf005

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/keys.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/keys.lua
@@ -1,0 +1,12 @@
+local map_lazy = require("cfg.keymap").map_lazy
+
+local M = {
+    map_lazy(
+        "n",
+        "<leader>nt",
+        "<cmd>Neotree toggle reveal<cr>",
+        { silent = false, desc = "Toggle file explorer" }
+    ),
+}
+
+return M


### PR DESCRIPTION
1. Use neo-tree for better performance on async following current file, replace nvim-tree.
2. Update neo-tree configs.
3. Add chadtree configs, but decide not to use it for reasons:
    * chadtree's UI looks more like nerdtree, not nvim-tree, which is not fancy.
    * lots of key mappings not compatible with nvim-tree.
    * python dependencies.