### PR TITLE
perf: optimize long file path in fzf

### DIFF
--- a/lua/repo/DNLHC/glance-nvim/config.lua
+++ b/lua/repo/DNLHC/glance-nvim/config.lua
@@ -13,9 +13,6 @@ glance.setup({
             ["v"] = false,
             ["<C-t>"] = actions.jump_tab,
             ["t"] = false,
-            ["<leader>,"] = actions.enter_win("preview"),
-            ["<leader>."] = actions.enter_win("preview"),
-            ["<leader>l"] = false,
         },
         preview = {
             -- quit
@@ -24,9 +21,6 @@ glance.setup({
             -- navigation
             ["<Tab>"] = false,
             ["<S-Tab>"] = false,
-            ["<leader>,"] = actions.enter_win("list"),
-            ["<leader>."] = actions.enter_win("list"),
-            ["<leader>l"] = false,
         },
     },
 })

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -7,7 +7,7 @@ local M = {
     keymap.map_lazy(
         "n",
         "<space>r",
-        keymap.exec("FzfRg"),
+        keymap.exec("FzfRg2"),
         { desc = "Search text" }
     ),
     keymap.map_lazy(

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -7,7 +7,7 @@ local M = {
     keymap.map_lazy(
         "n",
         "<space>r",
-        keymap.exec("FzfRg2"),
+        keymap.exec("FzfRg"),
         { desc = "Search text" }
     ),
     keymap.map_lazy(

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -123,6 +123,11 @@ require("neo-tree").setup({
             ["s"] = "none",
             ["t"] = "none",
 
+            -- preview
+            ["<C-l>"] = { "toggle_preview", config = { use_float = true } },
+            ["P"] = "none",
+
+            -- expand/collapse
             ["W"] = "close_all_nodes",
             ["E"] = "expand_all_nodes",
             ["z"] = "none",

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -8,7 +8,7 @@ function! s:lin_fzf_precised_rg(query, fullscreen)
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
-    let spec = fzf#vim#with_preview(spec, 'right,40%', 'ctrl-l')
+    let spec = fzf#vim#with_preview(spec)
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 
@@ -19,7 +19,7 @@ function! s:lin_fzf_unrestricted_precised_rg(query, fullscreen)
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
-    let spec = fzf#vim#with_preview(spec, 'right,40%', 'ctrl-l')
+    let spec = fzf#vim#with_preview(spec)
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,10 +1,10 @@
 command! -bang -nargs=* FzfUnrestrictedRg
             \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,
+            \ "rg -o --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 function! s:lin_fzf_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg --column --no-heading --color=always -- %s || true'
+    let command_fmt = 'rg -o --column --no-heading --color=always -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -13,7 +13,7 @@ function! s:lin_fzf_advanced_rg(query, fullscreen)
 endfunction
 
 function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg --column --no-heading --color=always -S -uu -- %s || true'
+    let command_fmt = 'rg -o --column --no-heading --color=always -S -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -27,12 +27,12 @@ command! -bang -nargs=* FzfUnrestrictedPrecisedRg call s:lin_fzf_unrestricted_ad
 
 command! -bang -nargs=0 FzfCWordRg
             \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -S ".shellescape(expand('<cword>')), 1,
+            \ "rg -o --column --no-heading --color=always -S ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 command! -bang -nargs=0 FzfUnrestrictedCWordRg
             \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -S -uu -g ".shellescape(expand('<cword>')), 1,
+            \ "rg -o --column --no-heading --color=always -S -uu -g ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 if executable('fd')

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,10 +1,10 @@
 command! -bang -nargs=* FzfRg2 call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -s -- ".shellescape(<q-args>), 1,
+            \ "rg --column --no-heading --color=always -s -- ".shellescape(<q-args>), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 command! -bang -nargs=* FzfUnrestrictedRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -s -uu ".shellescape(<q-args>), 1,
+            \ "rg --column --no-heading --color=always -s -uu ".shellescape(<q-args>), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 function! s:lin_fzf_advanced_rg(query, fullscreen)
@@ -36,7 +36,7 @@ command! -bang -nargs=0 FzfCWordRg
 
 command! -bang -nargs=0 FzfUnrestrictedCWordRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -s -uu -g ".shellescape(expand('<cword>')), 1,
+            \ "rg -o --column --no-heading --color=always -s -uu ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 if executable('fd')

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,9 +1,4 @@
-command! -bang -nargs=* FzfUnrestrictedRg
-            \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,
-            \ fzf#vim#with_preview(), <bang>0)
-
-function! s:lin_fzf_advanced_rg(query, fullscreen)
+function! s:lin_fzf_precised_rg(query, fullscreen)
     let command_fmt = 'rg --column --no-heading --color=always -S -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
@@ -12,7 +7,23 @@ function! s:lin_fzf_advanced_rg(query, fullscreen)
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 
-function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
+command! -bang -nargs=* FzfUnrestrictedRg
+            \ call fzf#vim#grep(
+            \ "rg --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,
+            \ fzf#vim#with_preview(), <bang>0)
+
+function! s:lin_fzf_precised_rg(query, fullscreen)
+    let command_fmt = 'rg --column --no-heading --color=always -S -- %s || true'
+    let initial_command = printf(command_fmt, shellescape(a:query))
+    let reload_command = printf(command_fmt, '{q}')
+    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
+    let spec = fzf#vim#with_preview(spec, 'right,40%', 'ctrl-l')
+    call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
+endfunction
+
+command! -bang -nargs=* FzfPrecisedRg call s:lin_fzf_precised_rg(<q-args>, <bang>0)
+
+function! s:lin_fzf_unrestricted_precised_rg(query, fullscreen)
     let command_fmt = 'rg --column --no-heading --color=always -S -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
@@ -21,9 +32,7 @@ function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 
-command! -bang -nargs=* FzfPrecisedRg call s:lin_fzf_advanced_rg(<q-args>, <bang>0)
-
-command! -bang -nargs=* FzfUnrestrictedPrecisedRg call s:lin_fzf_unrestricted_advanced_rg(<q-args>, <bang>0)
+command! -bang -nargs=* FzfUnrestrictedPrecisedRg call s:lin_fzf_unrestricted_precised_rg(<q-args>, <bang>0)
 
 command! -bang -nargs=0 FzfCWordRg
             \ call fzf#vim#grep(

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,12 +1,3 @@
-function! s:lin_fzf_precised_rg(query, fullscreen)
-    let command_fmt = 'rg --column --no-heading --color=always -S -- %s || true'
-    let initial_command = printf(command_fmt, shellescape(a:query))
-    let reload_command = printf(command_fmt, '{q}')
-    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
-    let spec = fzf#vim#with_preview(spec, 'right,40%', 'ctrl-l')
-    call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
-endfunction
-
 command! -bang -nargs=* FzfUnrestrictedRg
             \ call fzf#vim#grep(
             \ "rg --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -7,8 +7,8 @@ function! s:lin_fzf_advanced_rg(query, fullscreen)
     let command_fmt = 'rg --column --no-heading --color=always -S -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
-    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'ctrl-l:toggle-preview:change:reload:'.reload_command]}
-    let spec = fzf#vim#with_preview(spec, 'right', 'ctrl-/')
+    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
+    let spec = fzf#vim#with_preview(spec, 'right,40%', 'ctrl-l')
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 
@@ -16,8 +16,8 @@ function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
     let command_fmt = 'rg --column --no-heading --color=always -S -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
-    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'ctrl-l:toggle-preview:change:reload:'.reload_command]}
-    let spec = fzf#vim#with_preview(spec, 'right', 'ctrl-/')
+    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
+    let spec = fzf#vim#with_preview(spec, 'right,40%', 'ctrl-l')
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,5 +1,5 @@
 command! -bang -nargs=* FzfRg2 call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -s -- ".shellescape(<q-args>), 1,
+            \ "rg -o --column --no-heading --color=always -s -- ".shellescape(<q-args>), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 command! -bang -nargs=* FzfUnrestrictedRg

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,10 +1,14 @@
+command! -bang -nargs=* FzfRg2 call fzf#vim#grep(
+            \ "rg --column --no-heading --color=always -s -- ".shellescape(<q-args>), 1,
+            \ fzf#vim#with_preview(), <bang>0)
+
 command! -bang -nargs=* FzfUnrestrictedRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,
+            \ "rg -o --column --no-heading --color=always -s -uu ".shellescape(<q-args>), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 function! s:lin_fzf_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg -o --column --no-heading --color=always -- %s || true'
+    let command_fmt = 'rg -o --column --no-heading --color=always -s -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -13,7 +17,7 @@ function! s:lin_fzf_advanced_rg(query, fullscreen)
 endfunction
 
 function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg -o --column --no-heading --color=always -S -uu -- %s || true'
+    let command_fmt = 'rg -o --column --no-heading --color=always -s -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -27,12 +31,12 @@ command! -bang -nargs=* FzfUnrestrictedPrecisedRg call s:lin_fzf_unrestricted_ad
 
 command! -bang -nargs=0 FzfCWordRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -S ".shellescape(expand('<cword>')), 1,
+            \ "rg -o --column --no-heading --color=always -s ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 command! -bang -nargs=0 FzfUnrestrictedCWordRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -S -uu -g ".shellescape(expand('<cword>')), 1,
+            \ "rg -o --column --no-heading --color=always -s -uu -g ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 if executable('fd')

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -4,7 +4,7 @@ command! -bang -nargs=* FzfUnrestrictedRg
             \ fzf#vim#with_preview(), <bang>0)
 
 function! s:lin_fzf_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg -o --column --no-heading --color=always -S -- %s || true'
+    let command_fmt = 'rg --column --no-heading --color=always -S -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'ctrl-l:toggle-preview:change:reload:'.reload_command]}
@@ -13,7 +13,7 @@ function! s:lin_fzf_advanced_rg(query, fullscreen)
 endfunction
 
 function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg -o --column --no-heading --color=always -S -uu -- %s || true'
+    let command_fmt = 'rg --column --no-heading --color=always -S -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'ctrl-l:toggle-preview:change:reload:'.reload_command]}
@@ -27,12 +27,12 @@ command! -bang -nargs=* FzfUnrestrictedPrecisedRg call s:lin_fzf_unrestricted_ad
 
 command! -bang -nargs=0 FzfCWordRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -S ".shellescape(expand('<cword>')), 1,
+            \ "rg --column --no-heading --color=always -S ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 command! -bang -nargs=0 FzfUnrestrictedCWordRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -S -uu ".shellescape(expand('<cword>')), 1,
+            \ "rg --column --no-heading --color=always -S -uu ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 if executable('fd')

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,14 +1,10 @@
-command! -bang -nargs=* FzfRg2 call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -s -- ".shellescape(<q-args>), 1,
-            \ fzf#vim#with_preview(), <bang>0)
-
 command! -bang -nargs=* FzfUnrestrictedRg
             \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -s -uu ".shellescape(<q-args>), 1,
+            \ "rg --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 function! s:lin_fzf_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg -o --column --no-heading --color=always -s -- %s || true'
+    let command_fmt = 'rg -o --column --no-heading --color=always -S -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -17,7 +13,7 @@ function! s:lin_fzf_advanced_rg(query, fullscreen)
 endfunction
 
 function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
-    let command_fmt = 'rg -o --column --no-heading --color=always -s -uu -- %s || true'
+    let command_fmt = 'rg -o --column --no-heading --color=always -S -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -31,12 +27,12 @@ command! -bang -nargs=* FzfUnrestrictedPrecisedRg call s:lin_fzf_unrestricted_ad
 
 command! -bang -nargs=0 FzfCWordRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -s ".shellescape(expand('<cword>')), 1,
+            \ "rg -o --column --no-heading --color=always -S ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 command! -bang -nargs=0 FzfUnrestrictedCWordRg
             \ call fzf#vim#grep(
-            \ "rg -o --column --no-heading --color=always -s -uu ".shellescape(expand('<cword>')), 1,
+            \ "rg -o --column --no-heading --color=always -S -uu ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 if executable('fd')

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -7,7 +7,7 @@ function! s:lin_fzf_advanced_rg(query, fullscreen)
     let command_fmt = 'rg -o --column --no-heading --color=always -S -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
-    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
+    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'ctrl-l:toggle-preview:change:reload:'.reload_command]}
     let spec = fzf#vim#with_preview(spec, 'right', 'ctrl-/')
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
@@ -16,7 +16,7 @@ function! s:lin_fzf_unrestricted_advanced_rg(query, fullscreen)
     let command_fmt = 'rg -o --column --no-heading --color=always -S -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
-    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
+    let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'ctrl-l:toggle-preview:change:reload:'.reload_command]}
     let spec = fzf#vim#with_preview(spec, 'right', 'ctrl-/')
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -8,6 +8,7 @@ else
     echo 'Error: `fd` or `fdfind` not found!'
     echohl None
 endif
+let $FZF_DEFAULT_OPTS='--preview-window=right,40%'
 
 " preview/bat
 " let $BAT_THEME='base16'
@@ -15,7 +16,7 @@ let $BAT_STYLE='numbers,header'
 
 " ui
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
-let g:fzf_preview_window = ['right,40%', 'ctrl-l']
+let g:fzf_preview_window = ['', 'ctrl-l']
 
 " command prefix
 let g:fzf_command_prefix = 'Fzf'

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -8,7 +8,6 @@ else
     echo 'Error: `fd` or `fdfind` not found!'
     echohl None
 endif
-" let $FZF_DEFAULT_OPTS='--preview-window=right,40%'
 
 " preview/bat
 " let $BAT_THEME='base16'

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -12,8 +12,9 @@ endif
 " use base16 theme for better color capatibility
 " let $BAT_THEME='base16'
 
-" bigger window
+" UI
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
+let g:fzf_preview_window = ['right,40%', 'ctrl-p']
 
 " command prefix
 let g:fzf_command_prefix = 'Fzf'

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -15,7 +15,7 @@ let $BAT_STYLE='numbers,header'
 
 " ui
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
-let g:fzf_preview_window = ['right,40%', 'ctrl-l']
+" let g:fzf_preview_window = ['right,40%', 'ctrl-l']
 
 " command prefix
 let g:fzf_command_prefix = 'Fzf'

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -8,7 +8,7 @@ else
     echo 'Error: `fd` or `fdfind` not found!'
     echohl None
 endif
-let $FZF_DEFAULT_OPTS='--preview-window=right,40%'
+" let $FZF_DEFAULT_OPTS='--preview-window=right,40%'
 
 " preview/bat
 " let $BAT_THEME='base16'

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -9,10 +9,12 @@ else
     echohl None
 endif
 
-" use base16 theme for better color capatibility
-" let $BAT_THEME='base16'
 
-" UI
+" preview/bat
+" let $BAT_THEME='base16'
+let $BAT_STYLE='numbers,header'
+
+" ui
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
 let g:fzf_preview_window = ['right,40%', 'ctrl-p']
 

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -15,7 +15,7 @@ let $BAT_STYLE='numbers,header'
 
 " ui
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
-" let g:fzf_preview_window = ['right,40%', 'ctrl-l']
+let g:fzf_preview_window = ['right,40%', 'ctrl-l']
 
 " command prefix
 let g:fzf_command_prefix = 'Fzf'

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -9,14 +9,20 @@ else
     echohl None
 endif
 
-
 " preview/bat
 " let $BAT_THEME='base16'
 let $BAT_STYLE='numbers,header'
 
 " ui
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
-let g:fzf_preview_window = ['right,40%', 'ctrl-p']
+let g:fzf_preview_window = ['right,40%', 'ctrl-l']
 
 " command prefix
 let g:fzf_command_prefix = 'Fzf'
+
+" action
+let g:fzf_action = {
+            \ 'ctrl-t': 'tab split',
+            \ 'ctrl-x': 'split',
+            \ 'ctrl-v': 'vsplit',
+            \ }

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -16,7 +16,7 @@ let $BAT_STYLE='numbers,header'
 
 " ui
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
-let g:fzf_preview_window = ['', 'ctrl-l']
+let g:fzf_preview_window = ['right,40%', 'ctrl-l']
 
 " command prefix
 let g:fzf_command_prefix = 'Fzf'


### PR DESCRIPTION
1. Add `BAT_STYLE` to show filename in fzf preview window.
2. Set `right=40%` to fzf preview window.
3. Set `ctrl-l` to toggle fzf preview window.
5. Set fzf actions for edit/open.
6. Fix `FzfUnrestrictedCWordRg`.