### PR TITLE
plugin: add buffer_manager.nvim plugin

### DIFF
--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -367,6 +367,12 @@ return {
         cmd = { "Bdelete", "Bwipeout" },
         keys = lua_keys("moll/vim-bbye"),
     },
+    {
+        "j-morano/buffer_manager.nvim",
+        lazy = true,
+        config = lua_config("j-morano/buffer_manager.nvim"),
+        keys = lua_keys("j-morano/buffer_manager.nvim"),
+    },
     -- Indentline
     {
         "lukas-reineke/indent-blankline.nvim",

--- a/lua/repo/j-morano/buffer_manager-nvim/config.lua
+++ b/lua/repo/j-morano/buffer_manager-nvim/config.lua
@@ -1,0 +1,12 @@
+require("buffer_manager").setup({
+    select_menu_item_commands = {
+        v = {
+            key = "<C-v>",
+            command = "vsplit",
+        },
+        h = {
+            key = "<C-x>",
+            command = "split",
+        },
+    },
+})

--- a/lua/repo/j-morano/buffer_manager-nvim/keys.lua
+++ b/lua/repo/j-morano/buffer_manager-nvim/keys.lua
@@ -1,0 +1,12 @@
+local map_lazy = require("cfg.keymap").map_lazy
+
+local M = {
+    map_lazy(
+        "n",
+        "<leader>bm",
+        "<cmd>lua require('buffer_manager.ui').toggle_quick_menu()<cr>",
+        { desc = "Toggle buffer manager" }
+    ),
+}
+
+return M

--- a/lua/repo/moll/vim-bbye/keys.lua
+++ b/lua/repo/moll/vim-bbye/keys.lua
@@ -1,25 +1,18 @@
 local keymap = require("cfg.keymap")
 
-local M = {}
-
--- close buffer
-table.insert(
-    M,
+local M = {
     keymap.map_lazy(
         "n",
         "<leader>bd",
         keymap.exec("Bdelete"),
         { desc = "Close buffer" }
-    )
-)
-table.insert(
-    M,
+    ),
     keymap.map_lazy(
         "n",
         "<leader>bD",
         keymap.exec("Bdelete!"),
         { desc = "Close buffer forcibly!" }
-    )
-)
+    ),
+}
 
 return M


### PR DESCRIPTION
1. Add `buffer_manager.nvim` plugin, for better buffer management.
2. Rewrite vim-bbye keys.