### PR TITLE
config: add tabnew keys to buffer_manager.nvim

### DIFF
--- a/lua/repo/j-morano/buffer_manager-nvim/config.lua
+++ b/lua/repo/j-morano/buffer_manager-nvim/config.lua
@@ -1,5 +1,9 @@
 require("buffer_manager").setup({
     select_menu_item_commands = {
+        t = {
+            key = "<C-t>",
+            command = "tabnew",
+        },
         v = {
             key = "<C-v>",
             command = "vsplit",


### PR DESCRIPTION
1. add `<C-t> = tabnew` keys to buffer_manager.nvim. 