### PR TITLE
break: change key mappings <C-x> to <C-s> to open split on glance,neo-tree

### DIFF
--- a/lua/repo/DNLHC/glance-nvim/config.lua
+++ b/lua/repo/DNLHC/glance-nvim/config.lua
@@ -8,7 +8,7 @@ glance.setup({
     mappings = {
         list = {
             -- open
-            ["<C-x>"] = actions.jump_split,
+            ["<C-s>"] = actions.jump_split,
             ["s"] = false,
             ["<C-v>"] = actions.jump_vsplit,
             ["v"] = false,

--- a/lua/repo/ms-jpq/chadtree/init.lua
+++ b/lua/repo/ms-jpq/chadtree/init.lua
@@ -30,7 +30,7 @@ local chadtree_settings = {
         -- open in new tab, vsplit, split
         ["tertiary"] = { "<C-t>" },
         ["v_split"] = { "<C-v>" },
-        ["h_split"] = { "<C-x>" },
+        ["h_split"] = { "<C-s>" },
 
         -- open in system
         ["open_sys"] = { "s" },

--- a/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
+++ b/lua/repo/nvim-neo-tree/neo-tree-nvim/config.lua
@@ -106,7 +106,7 @@ require("neo-tree").setup({
             ["w"] = "none",
 
             -- open in split/vsplit/tab
-            ["<C-x>"] = "open_split",
+            ["<C-s>"] = "open_split",
             ["<C-v>"] = "open_vsplit",
             ["<C-t>"] = "open_tabnew",
             ["S"] = "none",

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -23,6 +23,6 @@ let g:fzf_command_prefix = 'Fzf'
 " action
 let g:fzf_action = {
             \ 'ctrl-t': 'tab split',
-            \ 'ctrl-x': 'split',
+            \ 'ctrl-s': 'split',
             \ 'ctrl-v': 'vsplit',
             \ }


### PR DESCRIPTION
1. change key mapping `<C-x>` to `<C-s>` on glance, neo-tree, fzf, chadtree(disabled).