### PR TITLE
feat(plugin): use fzf-lua instead of fzf.vim

### DIFF
--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -1,4 +1,5 @@
 -- ---- Plugins Header ----
+local const = require("cfg.const")
 
 local function lua_config(repo)
     local function wrap()
@@ -379,21 +380,21 @@ return {
         event = { CmdlineEnter },
         build = ":call fzf#install()",
     },
-    -- {
-    --     "junegunn/fzf.vim",
-    --     event = { CmdlineEnter },
-    --     dependencies = { "junegunn/fzf" },
-    --     init = vim_init("junegunn/fzf.vim"),
-    --     config = vim_config("junegunn/fzf.vim"),
-    --     keys = lua_keys("junegunn/fzf.vim"),
-    -- },
     {
+        "junegunn/fzf.vim",
+        event = { CmdlineEnter },
+        dependencies = { "junegunn/fzf" },
+        init = vim_init("junegunn/fzf.vim"),
+        config = vim_config("junegunn/fzf.vim"),
+        keys = const.os.is_windows and lua_keys("junegunn/fzf.vim") or {},
+    },
+    not const.os.is_windows and {
         "ibhagwan/fzf-lua",
         cmd = { "FzfLua" },
         dependencies = { "junegunn/fzf" },
         config = lua_config("ibhagwan/fzf-lua"),
         keys = lua_keys("ibhagwan/fzf-lua"),
-    },
+    } or {},
 
     -- ---- TAGS ----
 

--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -379,13 +379,20 @@ return {
         event = { CmdlineEnter },
         build = ":call fzf#install()",
     },
+    -- {
+    --     "junegunn/fzf.vim",
+    --     event = { CmdlineEnter },
+    --     dependencies = { "junegunn/fzf" },
+    --     init = vim_init("junegunn/fzf.vim"),
+    --     config = vim_config("junegunn/fzf.vim"),
+    --     keys = lua_keys("junegunn/fzf.vim"),
+    -- },
     {
-        "junegunn/fzf.vim",
-        event = { CmdlineEnter },
+        "ibhagwan/fzf-lua",
+        cmd = { "FzfLua" },
         dependencies = { "junegunn/fzf" },
-        init = vim_init("junegunn/fzf.vim"),
-        config = vim_config("junegunn/fzf.vim"),
-        keys = lua_keys("junegunn/fzf.vim"),
+        config = lua_config("ibhagwan/fzf-lua"),
+        keys = lua_keys("ibhagwan/fzf-lua"),
     },
 
     -- ---- TAGS ----

--- a/lua/repo/ibhagwan/fzf-lua/config.lua
+++ b/lua/repo/ibhagwan/fzf-lua/config.lua
@@ -10,7 +10,7 @@ require("fzf-lua").setup({
         preview = {
             default = "bat",
             border = const.ui.border,
-            horizontal = "right:40%",
+            horizontal = "right:45%",
         },
     },
     keymap = {
@@ -72,6 +72,10 @@ require("fzf-lua").setup({
             treesitter = { enable = false },
         },
     },
+    manpages = { previewer = "man_native" },
+    helptags = { previewer = "help_native" },
+    tags = { previewer = "bat" },
+    btags = { previewer = "bat" },
     files = {
         previewer = "bat",
         cmd = fzf_const.FILES_CMD,
@@ -79,4 +83,6 @@ require("fzf-lua").setup({
     grep = {
         cmd = fzf_const.GREP_CMD,
     },
+    global_git_icons = false,
+    global_file_icons = false,
 })

--- a/lua/repo/ibhagwan/fzf-lua/config.lua
+++ b/lua/repo/ibhagwan/fzf-lua/config.lua
@@ -1,0 +1,82 @@
+local const = require("cfg.const")
+local fzf_actions = require("fzf-lua.actions")
+local fzf_const = require("repo.ibhagwan.fzf-lua.const")
+
+require("fzf-lua").setup({
+    winopts = {
+        height = 0.85,
+        width = 0.95,
+        border = const.ui.border,
+        preview = {
+            default = "bat",
+            border = const.ui.border,
+            horizontal = "right:40%",
+        },
+    },
+    keymap = {
+        builtin = {
+            ["<C-l>"] = "toggle-preview",
+            ["<C-d>"] = "preview-page-down",
+            ["<C-u>"] = "preview-page-up",
+
+            ["<F1>"] = false, -- "toggle-help",
+            ["<F2>"] = false, --  "toggle-fullscreen",
+            ["<F3>"] = false, -- "toggle-preview-wrap",
+            ["<F4>"] = false, -- "toggle-preview",
+            ["<F5>"] = false, -- "toggle-preview-ccw",
+            ["<F6>"] = false, -- "toggle-preview-cw",
+            ["<S-down>"] = false, -- "preview-page-down",
+            ["<S-up>"] = false, -- "preview-page-up",
+            ["<S-left>"] = false, -- "preview-page-reset",
+        },
+        fzf = {
+            -- fzf '--bind=' options
+            ["ctrl-d"] = "half-page-down",
+            ["ctrl-u"] = "half-page-up", -- "unix-line-discard",
+            ["ctrl-l"] = "toggle-preview",
+            ["ctrl-z"] = false, -- "abort",
+            ["ctrl-f"] = false, -- "half-page-down",
+            ["ctrl-b"] = false, -- "half-page-up",
+            ["ctrl-a"] = false, -- "beginning-of-line",
+            ["ctrl-e"] = false, -- "end-of-line",
+            ["alt-a"] = false, -- "toggle-all",
+            ["f3"] = false, -- "toggle-preview-wrap",
+            ["f4"] = false, -- "toggle-preview",
+            ["shift-down"] = false, -- "preview-page-down",
+            ["shift-up"] = false, -- "preview-page-up",
+        },
+    },
+    actions = {
+        files = {
+            ["default"] = fzf_actions.file_edit, -- fzf_actions.file_edit_or_qf,
+            ["ctrl-s"] = fzf_actions.file_split,
+            ["ctrl-v"] = fzf_actions.file_vsplit,
+            ["ctrl-t"] = fzf_actions.file_tabedit,
+            ["alt-q"] = false, -- fzf_actions.file_sel_to_qf,
+            ["alt-l"] = false, -- fzf_actions.file_sel_to_ll,
+        },
+        buffers = {
+            ["default"] = fzf_actions.buf_edit,
+            ["ctrl-s"] = fzf_actions.buf_split,
+            ["ctrl-v"] = fzf_actions.buf_vsplit,
+            ["ctrl-t"] = fzf_actions.buf_tabedit,
+        },
+    },
+    previewers = {
+        bat = {
+            cmd = fzf_const.BAT,
+            args = "--style=numbers,changes,header --color always",
+            theme = "ansi",
+        },
+        builtin = {
+            treesitter = { enable = false },
+        },
+    },
+    files = {
+        previewer = "bat",
+        cmd = fzf_const.FILES_CMD,
+    },
+    grep = {
+        cmd = fzf_const.GREP_CMD,
+    },
+})

--- a/lua/repo/ibhagwan/fzf-lua/const.lua
+++ b/lua/repo/ibhagwan/fzf-lua/const.lua
@@ -1,0 +1,16 @@
+local FD = vim.fn.executable("fdfind") > 0 and "fdfind" or "fd"
+local BAT = vim.fn.executable("batcat") > 0 and "batcat" or "bat"
+
+local FILES_CMD = FD
+    .. " . --color=never --type f --type symlink --follow --ignore-case"
+local GREP_CMD =
+    "rg --column --line-number --no-heading --color=always --case-sensitive"
+
+local M = {
+    FD = FD,
+    BAT = BAT,
+    FILES_CMD = FILES_CMD,
+    GREP_CMD = GREP_CMD,
+}
+
+return M

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -1,0 +1,127 @@
+local keymap = require("cfg.keymap")
+local fzf_const = require("repo.ibhagwan.fzf-lua.const")
+
+local M = {
+    -- search files
+    keymap.map_lazy(
+        "n",
+        "<space>f",
+        keymap.exec(function()
+            require("fzf-lua").files()
+        end),
+        { desc = "Search files" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>uf",
+        keymap.exec(function()
+            require("fzf-lua").files({
+                files = {
+                    previewer = "bat",
+                    cmd = fzf_const.FILES_CMD .. " -u",
+                },
+            })
+        end),
+        { desc = "Unrestricted search files" }
+    ),
+    -- grep
+    keymap.map_lazy(
+        "n",
+        "<space>g",
+        keymap.exec(function()
+            require("fzf-lua").grep()
+        end),
+        { desc = "Grep" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>ug",
+        keymap.exec(function()
+            require("fzf-lua").grep({
+                grep = {
+                    cmd = fzf_const.GREP_CMD .. " -uu",
+                },
+            })
+        end),
+        { desc = "Unrestricted grep" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>pg",
+        keymap.exec(function()
+            require("fzf-lua").grep({
+                grep = {
+                    cmd = fzf_const.GREP_CMD,
+                    rg_glob = true,
+                    glob_flag = "--glob",
+                },
+            })
+        end),
+        { desc = "Glob patterned grep" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>upg",
+        keymap.exec(function()
+            require("fzf-lua").grep({
+                grep = {
+                    cmd = fzf_const.GREP_CMD .. " -uu",
+                    rg_glob = true,
+                    glob_flag = "--glob",
+                },
+            })
+        end),
+        { desc = "Unrestricted glob patterned grep" }
+    ),
+    -- live grep
+    keymap.map_lazy(
+        "n",
+        "<space>l",
+        keymap.exec(function()
+            require("fzf-lua").live_grep()
+        end),
+        { desc = "Live grep" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>ul",
+        keymap.exec(function()
+            require("fzf-lua").live_grep({
+                grep = {
+                    cmd = fzf_const.GREP_CMD .. " -uu",
+                },
+            })
+        end),
+        { desc = "Unrestricted live grep" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>pl",
+        keymap.exec(function()
+            require("fzf-lua").live_grep({
+                grep = {
+                    cmd = fzf_const.GREP_CMD,
+                    rg_glob = true,
+                    glob_flag = "--glob",
+                },
+            })
+        end),
+        { desc = "Glob patterned grep" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>upl",
+        keymap.exec(function()
+            require("fzf-lua").live_grep({
+                grep = {
+                    cmd = fzf_const.GREP_CMD .. " -uu",
+                    rg_glob = true,
+                    glob_flag = "--glob",
+                },
+            })
+        end),
+        { desc = "Unrestricted glob patterned live grep" }
+    ),
+}
+
+return M

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -9,7 +9,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").files()
         end),
-        { desc = "Search files(f)" }
+        { desc = "Search files(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -19,7 +19,7 @@ local M = {
                 cmd = fzf_const.FILES_CMD .. " -u",
             })
         end),
-        { desc = "Unrestricted(u) search files(f)" }
+        { desc = "Unrestricted search files(FzfLua)" }
     ),
     -- live grep
     keymap.map_lazy(
@@ -28,7 +28,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").live_grep()
         end),
-        { desc = "Live(l) grep" }
+        { desc = "Live grep(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -38,7 +38,7 @@ local M = {
                 cmd = fzf_const.GREP_CMD .. " -uu",
             })
         end),
-        { desc = "Unrestricted live grep" }
+        { desc = "Unrestricted live grep(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -47,10 +47,9 @@ local M = {
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD,
                 rg_glob = true,
-                glob_flag = "--glob",
             })
         end),
-        { desc = "Glob(g) grep(g)" }
+        { desc = "Glob live grep(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -59,19 +58,18 @@ local M = {
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD .. " -uu",
                 rg_glob = true,
-                glob_flag = "--glob",
             })
         end),
-        { desc = "Unrestricted(u) glob(g) live(l) grep" }
+        { desc = "Unrestricted glob live grep(FzfLua)" }
     ),
-    -- grep word
+    -- search word
     keymap.map_lazy(
         "n",
         "<space>w",
         keymap.exec(function()
             require("fzf-lua").grep_cword()
         end),
-        { desc = "Grep word(w)" }
+        { desc = "Search word under cursor(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -81,16 +79,16 @@ local M = {
                 cmd = fzf_const.GREP_CMD .. " -uu",
             })
         end),
-        { desc = "Unrestricted(u) grep word(w)" }
+        { desc = "Unrestricted search word under cursor(FzfLua)" }
     ),
-    -- grep WORD
+    -- search WORD
     keymap.map_lazy(
         "n",
         "<space>W",
         keymap.exec(function()
             require("fzf-lua").grep_cWORD()
         end),
-        { desc = "Grep WORD(W)" }
+        { desc = "Search WORD under cursor(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -100,10 +98,10 @@ local M = {
                 cmd = fzf_const.GREP_CMD .. " -uu",
             })
         end),
-        { desc = "Unrestricted(u) grep WORD(W)" }
+        { desc = "Unrestricted search WORD under cursor(FzfLua)" }
     ),
     -- FzfLua
-    keymap.map_lazy("n", "<Leader>fz", ":FzfLua ", { desc = "Open FzfLua" }),
+    keymap.map_lazy("n", "<Leader>fl", ":FzfLua ", { desc = "Open FzfLua" }),
 }
 
 return M

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -107,6 +107,8 @@ local M = {
         end),
         { desc = "Unrestricted(u) glob(o) live(l) grep" }
     ),
+    -- FzfLua
+    keymap.map_lazy("n", "<space>fz", ":FzfLua ", { desc = "Open FzfLua" }),
 }
 
 return M

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -108,7 +108,7 @@ local M = {
         { desc = "Unrestricted(u) glob(o) live(l) grep" }
     ),
     -- FzfLua
-    keymap.map_lazy("n", "<space>fz", ":FzfLua ", { desc = "Open FzfLua" }),
+    keymap.map_lazy("n", "<Leader>fz", ":FzfLua ", { desc = "Open FzfLua" }),
 }
 
 return M

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -21,49 +21,6 @@ local M = {
         end),
         { desc = "Unrestricted(u) search files(f)" }
     ),
-    -- grep
-    keymap.map_lazy(
-        "n",
-        "<space>g",
-        keymap.exec(function()
-            require("fzf-lua").grep()
-        end),
-        { desc = "Grep(g)" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>ug",
-        keymap.exec(function()
-            require("fzf-lua").grep({
-                cmd = fzf_const.GREP_CMD .. " -uu",
-            })
-        end),
-        { desc = "Unrestricted(u) grep(g)" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>og",
-        keymap.exec(function()
-            require("fzf-lua").grep({
-                cmd = fzf_const.GREP_CMD,
-                rg_glob = true,
-                glob_flag = "--glob",
-            })
-        end),
-        { desc = "Glob(o) grep(g)" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>uog",
-        keymap.exec(function()
-            require("fzf-lua").grep({
-                cmd = fzf_const.GREP_CMD .. " -uu",
-                rg_glob = true,
-                glob_flag = "--glob",
-            })
-        end),
-        { desc = "Unrestricted(u) glob(o) grep(g)" }
-    ),
     -- live grep
     keymap.map_lazy(
         "n",
@@ -85,7 +42,7 @@ local M = {
     ),
     keymap.map_lazy(
         "n",
-        "<space>ol",
+        "<space>gl",
         keymap.exec(function()
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD,
@@ -93,11 +50,11 @@ local M = {
                 glob_flag = "--glob",
             })
         end),
-        { desc = "Glob(o) grep(g)" }
+        { desc = "Glob(g) grep(g)" }
     ),
     keymap.map_lazy(
         "n",
-        "<space>uol",
+        "<space>ugl",
         keymap.exec(function()
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD .. " -uu",
@@ -105,7 +62,45 @@ local M = {
                 glob_flag = "--glob",
             })
         end),
-        { desc = "Unrestricted(u) glob(o) live(l) grep" }
+        { desc = "Unrestricted(u) glob(g) live(l) grep" }
+    ),
+    -- grep word
+    keymap.map_lazy(
+        "n",
+        "<space>w",
+        keymap.exec(function()
+            require("fzf-lua").grep_cword()
+        end),
+        { desc = "Grep word(w)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>uw",
+        keymap.exec(function()
+            require("fzf-lua").grep_cword({
+                cmd = fzf_const.GREP_CMD .. " -uu",
+            })
+        end),
+        { desc = "Unrestricted(u) grep word(w)" }
+    ),
+    -- grep WORD
+    keymap.map_lazy(
+        "n",
+        "<space>W",
+        keymap.exec(function()
+            require("fzf-lua").grep_cWORD()
+        end),
+        { desc = "Grep WORD(W)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>uw",
+        keymap.exec(function()
+            require("fzf-lua").grep_cWORD({
+                cmd = fzf_const.GREP_CMD .. " -uu",
+            })
+        end),
+        { desc = "Unrestricted(u) grep WORD(W)" }
     ),
     -- FzfLua
     keymap.map_lazy("n", "<Leader>fz", ":FzfLua ", { desc = "Open FzfLua" }),

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -9,20 +9,17 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").files()
         end),
-        { desc = "Search files" }
+        { desc = "Search files(f)" }
     ),
     keymap.map_lazy(
         "n",
         "<space>uf",
         keymap.exec(function()
             require("fzf-lua").files({
-                files = {
-                    previewer = "bat",
-                    cmd = fzf_const.FILES_CMD .. " -u",
-                },
+                cmd = fzf_const.FILES_CMD .. " -u",
             })
         end),
-        { desc = "Unrestricted search files" }
+        { desc = "Unrestricted(u) search files(f)" }
     ),
     -- grep
     keymap.map_lazy(
@@ -31,47 +28,41 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").grep()
         end),
-        { desc = "Grep" }
+        { desc = "Grep(g)" }
     ),
     keymap.map_lazy(
         "n",
         "<space>ug",
         keymap.exec(function()
             require("fzf-lua").grep({
-                grep = {
-                    cmd = fzf_const.GREP_CMD .. " -uu",
-                },
+                cmd = fzf_const.GREP_CMD .. " -uu",
             })
         end),
-        { desc = "Unrestricted grep" }
+        { desc = "Unrestricted(u) grep(g)" }
     ),
     keymap.map_lazy(
         "n",
-        "<space>pg",
+        "<space>og",
         keymap.exec(function()
             require("fzf-lua").grep({
-                grep = {
-                    cmd = fzf_const.GREP_CMD,
-                    rg_glob = true,
-                    glob_flag = "--glob",
-                },
+                cmd = fzf_const.GREP_CMD,
+                rg_glob = true,
+                glob_flag = "--glob",
             })
         end),
-        { desc = "Glob patterned grep" }
+        { desc = "Glob(o) grep(g)" }
     ),
     keymap.map_lazy(
         "n",
-        "<space>upg",
+        "<space>uog",
         keymap.exec(function()
             require("fzf-lua").grep({
-                grep = {
-                    cmd = fzf_const.GREP_CMD .. " -uu",
-                    rg_glob = true,
-                    glob_flag = "--glob",
-                },
+                cmd = fzf_const.GREP_CMD .. " -uu",
+                rg_glob = true,
+                glob_flag = "--glob",
             })
         end),
-        { desc = "Unrestricted glob patterned grep" }
+        { desc = "Unrestricted(u) glob(o) grep(g)" }
     ),
     -- live grep
     keymap.map_lazy(
@@ -80,47 +71,41 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").live_grep()
         end),
-        { desc = "Live grep" }
+        { desc = "Live(l) grep" }
     ),
     keymap.map_lazy(
         "n",
         "<space>ul",
         keymap.exec(function()
             require("fzf-lua").live_grep({
-                grep = {
-                    cmd = fzf_const.GREP_CMD .. " -uu",
-                },
+                cmd = fzf_const.GREP_CMD .. " -uu",
             })
         end),
         { desc = "Unrestricted live grep" }
     ),
     keymap.map_lazy(
         "n",
-        "<space>pl",
+        "<space>ol",
         keymap.exec(function()
             require("fzf-lua").live_grep({
-                grep = {
-                    cmd = fzf_const.GREP_CMD,
-                    rg_glob = true,
-                    glob_flag = "--glob",
-                },
+                cmd = fzf_const.GREP_CMD,
+                rg_glob = true,
+                glob_flag = "--glob",
             })
         end),
-        { desc = "Glob patterned grep" }
+        { desc = "Glob(o) grep(g)" }
     ),
     keymap.map_lazy(
         "n",
-        "<space>upl",
+        "<space>uol",
         keymap.exec(function()
             require("fzf-lua").live_grep({
-                grep = {
-                    cmd = fzf_const.GREP_CMD .. " -uu",
-                    rg_glob = true,
-                    glob_flag = "--glob",
-                },
+                cmd = fzf_const.GREP_CMD .. " -uu",
+                rg_glob = true,
+                glob_flag = "--glob",
             })
         end),
-        { desc = "Unrestricted glob patterned live grep" }
+        { desc = "Unrestricted(u) glob(o) live(l) grep" }
     ),
 }
 

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -1,63 +1,7 @@
 local keymap = require("cfg.keymap")
 
 local M = {
-
-    --  ---- Text ----
-    -- live grep
-    keymap.map_lazy(
-        "n",
-        "<space>r",
-        keymap.exec("FzfRg"),
-        { desc = "Search text" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>ur",
-        keymap.exec("FzfUnrestrictedRg"),
-        { desc = "Search text unrestrictedly" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>pr",
-        keymap.exec("FzfPrecisedRg"),
-        { desc = "Search text precisely" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>upr",
-        keymap.exec("FzfUnrestrictedPrecisedRg"),
-        { desc = "Search text unrestrictedly and precisely" }
-    ),
-    -- cursor word
-    keymap.map_lazy(
-        "n",
-        "<space>wr",
-        keymap.exec("FzfCWordRg"),
-        { desc = "Search cursor word" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>uwr",
-        keymap.exec("FzfUnrestrictedCWordRg"),
-        { desc = "Search cursor word unrestrictedly" }
-    ),
-    -- lines in current buffer
-    keymap.map_lazy(
-        "n",
-        "<space>ln",
-        keymap.exec("FzfLines"),
-        { desc = "Search lines" }
-    ),
-    -- tags
-    keymap.map_lazy(
-        "n",
-        "<space>tg",
-        keymap.exec("FzfTags"),
-        { desc = "Search tags" }
-    ),
-
-    -- ---- Files ----
-    -- files
+    -- search files
     keymap.map_lazy(
         "n",
         "<space>f",
@@ -70,116 +14,34 @@ local M = {
         keymap.exec("FzfUnrestrictedFiles"),
         { desc = "Search files unrestrictedly" }
     ),
-    -- files by cursor word
+    -- live grep
     keymap.map_lazy(
         "n",
-        "<space>wf",
-        keymap.exec("FzfCWordFiles"),
-        { desc = "Search files by cursor word" }
+        "<space>l",
+        keymap.exec("FzfLiveGrep"),
+        { desc = "Live grep(Fzf)" }
     ),
     keymap.map_lazy(
         "n",
-        "<space>uwf",
-        keymap.exec("FzfUnrestrictedCWordFiles"),
-        { desc = "Search files unrestrictedly by cursor word" }
+        "<space>ul",
+        keymap.exec("FzfUnrestrictedLiveGrep"),
+        { desc = "Unrestricted live grep(Fzf)" }
     ),
-    -- opened buffers
+    -- search word
     keymap.map_lazy(
         "n",
-        "<space>bf",
-        keymap.exec("FzfBuffers"),
-        { desc = "Search buffers" }
+        "<space>w",
+        keymap.exec("FzfCWord"),
+        { desc = "Search word under cursor(Fzf)" }
     ),
-    -- history files/oldfiles
     keymap.map_lazy(
         "n",
-        "<space>hf",
-        keymap.exec("FzfHistory"),
-        { desc = "Search history files" }
+        "<space>uw",
+        keymap.exec("FzfUnrestrictedCWord"),
+        { desc = "Unrestricted search word under cursor(Fzf)" }
     ),
-
-    -- ---- History ----
-    -- search history
-    keymap.map_lazy(
-        "n",
-        "<space>hs",
-        keymap.exec("FzfHistory/"),
-        { desc = "Search *search* histories(/)" }
-    ),
-    -- vim command history
-    keymap.map_lazy(
-        "n",
-        "<space>hc",
-        keymap.exec("FzfHistory:"),
-        { desc = "Search command histories(:)" }
-    ),
-
-    -- ---- Git ----
-    -- git commits
-    keymap.map_lazy(
-        "n",
-        "<space>gc",
-        keymap.exec("FzfCommits"),
-        { desc = "Search git commits" }
-    ),
-    -- git files
-    keymap.map_lazy(
-        "n",
-        "<space>gf",
-        keymap.exec("FzfGFiles"),
-        { desc = "Search git repository files(`git ls-files`)" }
-    ),
-    -- git status files
-    keymap.map_lazy(
-        "n",
-        "<space>gs",
-        keymap.exec("FzfGFiles?"),
-        { desc = "Search git status files(`git status`)" }
-    ),
-
-    -- ---- Vim ----
-    -- vim marks
-    keymap.map_lazy(
-        "n",
-        "<space>mk",
-        keymap.exec("FzfMarks"),
-        { desc = "Search vim marks" }
-    ),
-    -- vim key mappings
-    keymap.map_lazy(
-        "n",
-        "<space>mp",
-        keymap.exec("FzfMaps"),
-        { desc = "Search key mappings" }
-    ),
-    -- vim commands
-    keymap.map_lazy(
-        "n",
-        "<space>cm",
-        keymap.exec("FzfCommands"),
-        { desc = "Search vim commands" }
-    ),
-    -- vim help tags
-    keymap.map_lazy(
-        "n",
-        "<space>ht",
-        keymap.exec("FzfHelptags"),
-        { desc = "Search helptags" }
-    ),
-    -- vim colorschemes
-    keymap.map_lazy(
-        "n",
-        "<space>cs",
-        keymap.exec("FzfColors"),
-        { desc = "Search colorschemes" }
-    ),
-    -- vim filetypes
-    keymap.map_lazy(
-        "n",
-        "<space>tp",
-        keymap.exec("FzfFiletypes"),
-        { desc = "Search filetypes" }
-    ),
+    -- Fzf
+    keymap.map_lazy("n", "<Leader>fz", ":Fzf", { desc = "Open Fzf" }),
 }
 
 return M

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,10 +1,7 @@
-command! -bang -nargs=* FzfUnrestrictedRg
-            \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -S -uu ".shellescape(<q-args>), 1,
-            \ fzf#vim#with_preview(), <bang>0)
+let s:lin_rg = 'rg --column --line-number --no-heading --color=always --case-sensitive'
 
-function! s:lin_fzf_precised_rg(query, fullscreen)
-    let command_fmt = 'rg --column --no-heading --color=always -S -- %s || true'
+function! s:lin_fzf_live_grep(query, fullscreen)
+    let command_fmt = s:lin_rg.' -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -12,10 +9,10 @@ function! s:lin_fzf_precised_rg(query, fullscreen)
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 
-command! -bang -nargs=* FzfPrecisedRg call s:lin_fzf_precised_rg(<q-args>, <bang>0)
+command! -bang -nargs=* FzfLiveGrep call s:lin_fzf_live_grep(<q-args>, <bang>0)
 
-function! s:lin_fzf_unrestricted_precised_rg(query, fullscreen)
-    let command_fmt = 'rg --column --no-heading --color=always -S -uu -- %s || true'
+function! s:lin_fzf_unrestricted_live_grep(query, fullscreen)
+    let command_fmt = s:lin_rg.' -uu -- %s || true'
     let initial_command = printf(command_fmt, shellescape(a:query))
     let reload_command = printf(command_fmt, '{q}')
     let spec = {'options': ['--disabled', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
@@ -23,41 +20,41 @@ function! s:lin_fzf_unrestricted_precised_rg(query, fullscreen)
     call fzf#vim#grep(initial_command, 1, spec, a:fullscreen)
 endfunction
 
-command! -bang -nargs=* FzfUnrestrictedPrecisedRg call s:lin_fzf_unrestricted_precised_rg(<q-args>, <bang>0)
+command! -bang -nargs=* FzfUnrestrictedLiveGrep call s:lin_fzf_unrestricted_live_grep(<q-args>, <bang>0)
 
-command! -bang -nargs=0 FzfCWordRg
+command! -bang -nargs=0 FzfCWord
             \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -S ".shellescape(expand('<cword>')), 1,
+            \ s:lin_rg." ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
-command! -bang -nargs=0 FzfUnrestrictedCWordRg
+command! -bang -nargs=0 FzfUnrestrictedCWord
             \ call fzf#vim#grep(
-            \ "rg --column --no-heading --color=always -S -uu ".shellescape(expand('<cword>')), 1,
+            \ s:lin_rg." -uu ".shellescape(expand('<cword>')), 1,
             \ fzf#vim#with_preview(), <bang>0)
 
 if executable('fd')
-    let s:lin_find_command = 'fd'
+    let s:lin_fd = 'fd --color=never --type f --type symlink --follow --ignore-case'
 elseif executable('fdfind')
-    let s:lin_find_command = 'fdfind'
+    let s:lin_fd = 'fdfind --color=never --type f --type symlink --follow --ignore-case'
 endif
 
 command! -bang -nargs=? -complete=dir FzfUnrestrictedFiles
             \ call fzf#run(
             \   fzf#vim#with_preview(
-            \     fzf#wrap({ 'source': s:lin_find_command." -tf -tl -i -u ".shellescape(<q-args>) }, <bang>0)
+            \     fzf#wrap({ 'source': s:lin_fd." -u ".shellescape(<q-args>) }, <bang>0)
             \   )
             \ )
 
 command! -bang -nargs=? -complete=dir FzfCWordFiles
             \ call fzf#run(
             \   fzf#vim#with_preview(
-            \     fzf#wrap({ 'source': s:lin_find_command.' -tf -tl -i '.shellescape(expand('<cword>')) }, <bang>0)
+            \     fzf#wrap({ 'source': s:lin_fd.' '.shellescape(expand('<cword>')) }, <bang>0)
             \   )
             \ )
 
 command! -bang -nargs=? -complete=dir FzfUnrestrictedCWordFiles
             \ call fzf#run(
             \   fzf#vim#with_preview(
-            \     fzf#wrap({ 'source': s:lin_find_command." -tf -tl -i -u ".shellescape(expand('<cword>')) }, <bang>0)
+            \     fzf#wrap({ 'source': s:lin_fd." -u ".shellescape(expand('<cword>')) }, <bang>0)
             \   )
             \ )

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -1,17 +1,18 @@
 " use fd for fzf file finding, instead of default find
 if executable('fd')
-    let $FZF_DEFAULT_COMMAND = 'fd -tf -tl -i'
+    let $FZF_DEFAULT_COMMAND = 'fd --color=never --type f --type symlink --follow --ignore-case'
 elseif executable('fdfind')
-    let $FZF_DEFAULT_COMMAND = 'fdfind -tf -tl -i'
+    let $FZF_DEFAULT_COMMAND = 'fdfind --color=never --type f --type symlink --follow --ignore-case'
 else
     echohl ErrorMsg
     echo 'Error: `fd` or `fdfind` not found!'
     echohl None
 endif
+let $FZF_DEFAULT_OPTS = '--ansi --info=inline --height=100% --layout=reverse'
 
 " preview/bat
-" let $BAT_THEME='base16'
-let $BAT_STYLE='numbers,header'
+let $BAT_THEME='ansi'
+let $BAT_STYLE='numbers,changes,header'
 
 " ui
 let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }


### PR DESCRIPTION
1. add plugin fzf-lua, replace fzf.vim under linux/macOS. fzf-lua support `glob`.
3. use ignore-case for file, sensitive-case for grep.
4. only set keys for file search, live grep and word grep, remove other keys.
5. fzf-lua is not working under windows, still keep fzf-vim under windows.
6. update fzf-lua and fzf-vim styling, keep them compatible.