### PR TITLE
break: remove `<Leader>fz`(fzf.vim) and `<Leader>fl`(fzf-lua) keys

### DIFF
--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -100,8 +100,6 @@ local M = {
         end),
         { desc = "Unrestricted search WORD under cursor(FzfLua)" }
     ),
-    -- FzfLua
-    keymap.map_lazy("n", "<Leader>fl", ":FzfLua ", { desc = "Open FzfLua" }),
 }
 
 return M

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -40,8 +40,6 @@ local M = {
         keymap.exec("FzfUnrestrictedCWord"),
         { desc = "Unrestricted search word under cursor(Fzf)" }
     ),
-    -- Fzf
-    keymap.map_lazy("n", "<Leader>fz", ":Fzf", { desc = "Open Fzf" }),
 }
 
 return M


### PR DESCRIPTION
1. remove `<Leader>fz`(fzf.vim) and `<Leader>fl`(fzf-lua) keys