### PR TITLE
config: shorten fzf command line, add icons for fzf-lua

### DIFF
--- a/lua/repo/ibhagwan/fzf-lua/config.lua
+++ b/lua/repo/ibhagwan/fzf-lua/config.lua
@@ -4,8 +4,8 @@ local fzf_const = require("repo.ibhagwan.fzf-lua.const")
 
 require("fzf-lua").setup({
     winopts = {
-        height = 0.85,
-        width = 0.95,
+        height = 0.8,
+        width = 0.9,
         border = const.ui.border,
         preview = {
             default = "bat",
@@ -34,6 +34,7 @@ require("fzf-lua").setup({
             ["ctrl-d"] = "half-page-down",
             ["ctrl-u"] = "half-page-up", -- "unix-line-discard",
             ["ctrl-l"] = "toggle-preview",
+
             ["ctrl-z"] = false, -- "abort",
             ["ctrl-f"] = false, -- "half-page-down",
             ["ctrl-b"] = false, -- "half-page-up",
@@ -52,6 +53,7 @@ require("fzf-lua").setup({
             ["ctrl-s"] = fzf_actions.file_split,
             ["ctrl-v"] = fzf_actions.file_vsplit,
             ["ctrl-t"] = fzf_actions.file_tabedit,
+
             ["alt-q"] = false, -- fzf_actions.file_sel_to_qf,
             ["alt-l"] = false, -- fzf_actions.file_sel_to_ll,
         },
@@ -83,6 +85,4 @@ require("fzf-lua").setup({
     grep = {
         cmd = fzf_const.GREP_CMD,
     },
-    global_git_icons = false,
-    global_file_icons = false,
 })

--- a/lua/repo/ibhagwan/fzf-lua/const.lua
+++ b/lua/repo/ibhagwan/fzf-lua/const.lua
@@ -1,10 +1,12 @@
 local FD = vim.fn.executable("fdfind") > 0 and "fdfind" or "fd"
 local BAT = vim.fn.executable("batcat") > 0 and "batcat" or "bat"
 
-local FILES_CMD = FD
-    .. " . --color=never --type f --type symlink --follow --ignore-case"
-local GREP_CMD =
-    "rg --column --line-number --no-heading --color=always --case-sensitive"
+-- local FILES_CMD = FD
+--     .. " . --color=never --type f --type symlink --follow --ignore-case"
+local FILES_CMD = FD .. " -cnever -tf -tl -L -i"
+-- local GREP_CMD =
+--     "rg --column --line-number --no-heading --color=always --smart-case"
+local GREP_CMD = "rg --column -n --no-heading --color=always -S"
 
 local M = {
     FD = FD,

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -16,7 +16,7 @@ local M = {
         "<space>uf",
         keymap.exec(function()
             require("fzf-lua").files({
-                cmd = fzf_const.FILES_CMD .. " -u",
+                cmd = fzf_const.FILES_CMD .. " -u", -- --unrestricted
             })
         end),
         { desc = "Unrestricted search files(FzfLua)" }
@@ -35,7 +35,7 @@ local M = {
         "<space>ul",
         keymap.exec(function()
             require("fzf-lua").live_grep({
-                cmd = fzf_const.GREP_CMD .. " -uu",
+                cmd = fzf_const.GREP_CMD .. " -uu", -- --unrestricted --hidden
             })
         end),
         { desc = "Unrestricted live grep(FzfLua)" }
@@ -92,7 +92,7 @@ local M = {
     ),
     keymap.map_lazy(
         "n",
-        "<space>uw",
+        "<space>uW",
         keymap.exec(function()
             require("fzf-lua").grep_cWORD({
                 cmd = fzf_const.GREP_CMD .. " -uu",

--- a/repo/junegunn/fzf.vim/config.vim
+++ b/repo/junegunn/fzf.vim/config.vim
@@ -1,4 +1,5 @@
-let s:lin_rg = 'rg --column --line-number --no-heading --color=always --case-sensitive'
+" let s:lin_rg = 'rg --column --line-number --no-heading --color=always --smart-case'
+let s:lin_rg = 'rg --column -n --no-heading --color=always -S'
 
 function! s:lin_fzf_live_grep(query, fullscreen)
     let command_fmt = s:lin_rg.' -- %s || true'
@@ -33,9 +34,10 @@ command! -bang -nargs=0 FzfUnrestrictedCWord
             \ fzf#vim#with_preview(), <bang>0)
 
 if executable('fd')
-    let s:lin_fd = 'fd --color=never --type f --type symlink --follow --ignore-case'
+    " let s:lin_fd = 'fd --color=never --type f --type symlink --follow --ignore-case'
+    let s:lin_fd = 'fd -cnever -tf -tl -L -i'
 elseif executable('fdfind')
-    let s:lin_fd = 'fdfind --color=never --type f --type symlink --follow --ignore-case'
+    let s:lin_fd = 'fdfind -cnever -tf -tl -L -i'
 endif
 
 command! -bang -nargs=? -complete=dir FzfUnrestrictedFiles

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -1,8 +1,9 @@
 " use fd for fzf file finding, instead of default find
 if executable('fd')
-    let $FZF_DEFAULT_COMMAND = 'fd --color=never --type f --type symlink --follow --ignore-case'
+    " let $FZF_DEFAULT_COMMAND = 'fd --color=never --type f --type symlink --follow --ignore-case'
+    let $FZF_DEFAULT_COMMAND = 'fd -cnever -tf -tl -L -i'
 elseif executable('fdfind')
-    let $FZF_DEFAULT_COMMAND = 'fdfind --color=never --type f --type symlink --follow --ignore-case'
+    let $FZF_DEFAULT_COMMAND = 'fdfind -cnever -tf -tl -L -i'
 else
     echohl ErrorMsg
     echo 'Error: `fd` or `fdfind` not found!'
@@ -15,8 +16,8 @@ let $BAT_THEME='ansi'
 let $BAT_STYLE='numbers,changes,header'
 
 " ui
-let g:fzf_layout = { 'window': { 'width': 0.95, 'height': 0.85 } }
-let g:fzf_preview_window = ['right,40%', 'ctrl-l']
+let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.8 } }
+let g:fzf_preview_window = ['right,45%', 'ctrl-l']
 
 " command prefix
 let g:fzf_command_prefix = 'Fzf'


### PR DESCRIPTION
1. add icons for fzf-lua, adjust window size for fzf.vim/fzf-lua.
2. use shorter rg/fd command options, sometimes there're command line length limitation, and shorter command line maybe help debug issues.