### PR TITLE
plugin: remove nvim-treesitter-context

### DIFF
--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -261,12 +261,6 @@ return {
         config = lua_config("nvim-treesitter/nvim-treesitter"),
     },
     {
-        "nvim-treesitter/nvim-treesitter-context",
-        dependencies = { "nvim-treesitter/nvim-treesitter" },
-        event = { VeryLazy, BufRead, BufNewFile },
-        config = lua_config("nvim-treesitter/nvim-treesitter-context"),
-    },
-    {
         "RRethy/vim-illuminate",
         event = { VeryLazy, BufRead, BufNewFile },
         config = lua_config("RRethy/vim-illuminate"),


### PR DESCRIPTION
1. remove nvim-treesitter-context, since it's too noisy and conflict with barbecue and matchup.