### PR TITLE
legacy: remove language messages

### DIFF
--- a/cfg/basic.vim
+++ b/cfg/basic.vim
@@ -113,7 +113,6 @@ if has('termguicolors')
 endif
 
 """ EN language
-language messages en_US.UTF-8
 set langmenu=en_US
 set nolangremap
 


### PR DESCRIPTION
1. remove `language messages` legacy, since it's reporting error message since nvim 0.9