### PR TITLE
fix: missing copy keys for gitlinker

### DIFF
--- a/lua/repo/linrongbin16/gitlinker-nvim/keys.lua
+++ b/lua/repo/linrongbin16/gitlinker-nvim/keys.lua
@@ -7,6 +7,12 @@ local M = {
         '<cmd>lua require("gitlinker").link()<cr>',
         { desc = "Open git link in browser" }
     ),
+    map_lazy(
+        { "n", "x" },
+        "<leader>gL",
+        '<cmd>lua require("gitlinker").link({action = require("gitlinker.actions").clipboard})<cr>',
+        { desc = "Copy git link to clipboard" }
+    ),
 }
 
 return M


### PR DESCRIPTION
1. add `<leader>gL` (copy git link to clipboard) keys