### PR TITLE
break: disable cmp-tags and tagfunc

### DIFF
--- a/lua/cfg/lsp/setup.lua
+++ b/lua/cfg/lsp/setup.lua
@@ -5,6 +5,8 @@ local function on_attach(client, bufnr)
     end
     -- async code format
     require("lspformatter").on_attach(client, bufnr)
+    -- disable tagfunc to fix workspace/symbol not support error
+    vim.bo.tagfunc = nil
 end
 
 local M = {

--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -462,7 +462,6 @@ local M = {
             "hrsh7th/cmp-cmdline",
             "L3MON4D3/LuaSnip",
             "saadparwaiz1/cmp_luasnip",
-            "quangnguyen30192/cmp-nvim-tags",
         },
         config = lua_config("hrsh7th/nvim-cmp"),
     },
@@ -491,10 +490,6 @@ local M = {
         "saadparwaiz1/cmp_luasnip",
         event = { VeryLazy, InsertEnter, CmdlineEnter },
         dependencies = { "L3MON4D3/LuaSnip" },
-    },
-    {
-        "quangnguyen30192/cmp-nvim-tags",
-        event = { VeryLazy, InsertEnter, CmdlineEnter },
     },
     {
         "DNLHC/glance.nvim",

--- a/lua/cfg/user_plugins_sample.lua
+++ b/lua/cfg/user_plugins_sample.lua
@@ -50,4 +50,9 @@ return {
         event = { VeryLazy, InsertEnter, CmdlineEnter },
         config = lua_config("zbirenbaum/copilot.lua"),
     },
+    -- tags
+    {
+        "quangnguyen30192/cmp-nvim-tags",
+        event = { VeryLazy, InsertEnter, CmdlineEnter },
+    },
 }

--- a/lua/repo/hrsh7th/nvim-cmp/config.lua
+++ b/lua/repo/hrsh7th/nvim-cmp/config.lua
@@ -28,7 +28,6 @@ local setup_handler = {
     }, {
         { name = "buffer", keyword_length = 2 },
         { name = "path", keyword_length = 2 },
-        { name = "tags", keyword_length = 2 },
     }),
     window = {
         completion = cmp.config.window.bordered(),

--- a/lua/repo/hrsh7th/nvim-cmp/setup_handler_sample.lua
+++ b/lua/repo/hrsh7th/nvim-cmp/setup_handler_sample.lua
@@ -8,15 +8,14 @@ local setup_handler = {
         { name = "copilot", keyword_length = 2 }, -- github copilot
         { name = "buffer", keyword_length = 2 },
         { name = "path", keyword_length = 2 },
-        { name = "tags", keyword_length = 2 },
+        { name = "tags", keyword_length = 2 }, -- tags
     }),
     sorting = {
         priority_weight = 2,
         comparators = {
             require("copilot_cmp.comparators").prioritize, -- github copilot
-            -- Below is the default comparitor list and order for nvim-cmp
             cmp.config.compare.offset,
-            -- cmp.config.compare.scopes, --this is commented in nvim-cmp too
+            cmp.config.compare.scopes,
             cmp.config.compare.exact,
             cmp.config.compare.score,
             cmp.config.compare.recently_used,


### PR DESCRIPTION
1. remove cmp-tags from nvim-cmp source since performance issue
2. disable tagfunc to fix workspace/symbol error