### PR TITLE
config: remove separator from nvim treesitter context

### DIFF
--- a/lua/repo/nvim-treesitter/nvim-treesitter-context/config.lua
+++ b/lua/repo/nvim-treesitter/nvim-treesitter-context/config.lua
@@ -1,5 +1,4 @@
 require("treesitter-context").setup({
     -- separator = "┄", -- U+2504: https://symbl.cc/en/2504/
-    max_lines = 5,
-    min_window_height = 10,
+    min_window_height = 30,
 })

--- a/lua/repo/nvim-treesitter/nvim-treesitter-context/config.lua
+++ b/lua/repo/nvim-treesitter/nvim-treesitter-context/config.lua
@@ -1,5 +1,5 @@
 require("treesitter-context").setup({
-    separator = "┄", -- U+2504: https://symbl.cc/en/2504/
+    -- separator = "┄", -- U+2504: https://symbl.cc/en/2504/
     max_lines = 5,
     min_window_height = 10,
 })

--- a/lua/repo/nvim-treesitter/nvim-treesitter-context/config.lua
+++ b/lua/repo/nvim-treesitter/nvim-treesitter-context/config.lua
@@ -1,3 +1,5 @@
 require("treesitter-context").setup({
     separator = "┄", -- U+2504: https://symbl.cc/en/2504/
+    max_lines = 5,
+    min_window_height = 10,
 })


### PR DESCRIPTION
1. remove separator from nvim-treesitter-context
2. set min height to 30