### PR TITLE
break: add fzf back

### DIFF
--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -1,5 +1,7 @@
 -- ---- Plugins ----
 
+local const = require("cfg.const")
+
 local function lua_config(repo)
     return function()
         local config_path = "repo." .. repo:gsub("%.", "-") .. ".config"
@@ -380,30 +382,50 @@ local M = {
 
     -- ---- SEARCH ----
 
+    -- {
+    --     "nvim-telescope/telescope.nvim",
+    --     branch = "0.1.x",
+    --     cmd = { "Telescope" },
+    --     dependencies = {
+    --         "nvim-telescope/telescope-fzf-native.nvim",
+    --         "nvim-telescope/telescope-live-grep-args.nvim",
+    --         "debugloop/telescope-undo.nvim",
+    --     },
+    --     config = lua_config("nvim-telescope/telescope.nvim"),
+    --     keys = lua_keys("nvim-telescope/telescope.nvim"),
+    -- },
+    -- {
+    --     "nvim-telescope/telescope-fzf-native.nvim",
+    --     build = "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build",
+    --     lazy = true,
+    -- },
+    -- {
+    --     "nvim-telescope/telescope-live-grep-args.nvim",
+    --     lazy = true,
+    -- },
+    -- {
+    --     "debugloop/telescope-undo.nvim",
+    --     lazy = true,
+    -- },
+    -- Fzf
     {
-        "nvim-telescope/telescope.nvim",
-        branch = "0.1.x",
-        cmd = { "Telescope" },
-        dependencies = {
-            "nvim-telescope/telescope-fzf-native.nvim",
-            "nvim-telescope/telescope-live-grep-args.nvim",
-            "debugloop/telescope-undo.nvim",
-        },
-        config = lua_config("nvim-telescope/telescope.nvim"),
-        keys = lua_keys("nvim-telescope/telescope.nvim"),
+        "junegunn/fzf",
+        event = { CmdlineEnter },
+        build = ":call fzf#install()",
     },
-    {
-        "nvim-telescope/telescope-fzf-native.nvim",
-        build = "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release && cmake --install build --prefix build",
-        lazy = true,
-    },
-    {
-        "nvim-telescope/telescope-live-grep-args.nvim",
-        lazy = true,
-    },
-    {
-        "debugloop/telescope-undo.nvim",
-        lazy = true,
+    const.os.is_windows and {
+        "junegunn/fzf.vim",
+        event = { CmdlineEnter },
+        dependencies = { "junegunn/fzf" },
+        init = vim_init("junegunn/fzf.vim"),
+        config = vim_config("junegunn/fzf.vim"),
+        keys = lua_keys("junegunn/fzf.vim"),
+    } or {
+        "ibhagwan/fzf-lua",
+        cmd = { "FzfLua" },
+        dependencies = { "junegunn/fzf" },
+        config = lua_config("ibhagwan/fzf-lua"),
+        keys = lua_keys("ibhagwan/fzf-lua"),
     },
 
     -- ---- TAGS ----

--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -483,7 +483,7 @@ local M = {
     },
     {
         "hrsh7th/cmp-nvim-lsp",
-        event = { VeryLazy, InsertEnter },
+        event = { VeryLazy, InsertEnter, CmdlineEnter },
     },
     {
         "hrsh7th/cmp-buffer",
@@ -495,12 +495,12 @@ local M = {
     },
     {
         "L3MON4D3/LuaSnip",
-        event = { VeryLazy, InsertEnter },
+        event = { VeryLazy, InsertEnter, CmdlineEnter },
         version = "1.*",
     },
     {
         "saadparwaiz1/cmp_luasnip",
-        event = { VeryLazy, InsertEnter },
+        event = { VeryLazy, InsertEnter, CmdlineEnter },
         dependencies = { "L3MON4D3/LuaSnip" },
     },
     {

--- a/lua/cfg/user_plugins_sample.lua
+++ b/lua/cfg/user_plugins_sample.lua
@@ -55,7 +55,7 @@ return {
         "quangnguyen30192/cmp-nvim-tags",
         event = { VeryLazy, InsertEnter, CmdlineEnter },
     },
-    -- structure outlines based on tags
+    -- tags/structure outlines
     {
         "liuchengxu/vista.vim",
         cmd = { "Vista" },
@@ -92,5 +92,11 @@ return {
             or ":call doge#install()",
         init = vim_init("kkoomen/vim-doge"),
         keys = lua_keys("kkoomen/vim-doge"),
+    },
+    -- Undo tree
+    {
+        "mbbill/undotree",
+        event = { VeryLazy, CmdlineEnter },
+        keys = lua_keys("mbbill/undotree"),
     },
 }

--- a/lua/repo/akinsho/bufferline-nvim/config.lua
+++ b/lua/repo/akinsho/bufferline-nvim/config.lua
@@ -1,4 +1,5 @@
 local width_on_editor = require("cfg.ui").editor_width
+local MAX_NAME_LENGTH = width_on_editor(0.2, 15, 40)
 
 require("bufferline").setup({
     options = {
@@ -8,8 +9,20 @@ require("bufferline").setup({
         -- numbers = "ordinal",
         close_command = "Bdelete! %d", -- Bdelete: https://github.com/moll/vim-bbye
         right_mouse_command = "Bdelete! %d",
-        max_name_length = width_on_editor(0.2, 25, 40),
-        max_prefix_length = width_on_editor(0.15, 15, 25),
+        name_formatter = function(buf) -- buf contains:
+            local name = buf.name
+            local len = name ~= nil and string.len(name) or 0
+            if len > MAX_NAME_LENGTH then
+                local half =
+                    math.floor(vim.fn.max({ (MAX_NAME_LENGTH - 1) / 2, 1 }))
+                local left = string.sub(name, 1, half)
+                local right = string.sub(name, len - half, len)
+                name = left .. "┄" .. right
+            end
+            return name
+        end,
+        max_name_length = MAX_NAME_LENGTH,
+        max_prefix_length = width_on_editor(0.1, 5, 10),
         diagnostics = false,
         -- separator_style = "slant",
         hover = {

--- a/lua/repo/akinsho/bufferline-nvim/config.lua
+++ b/lua/repo/akinsho/bufferline-nvim/config.lua
@@ -13,8 +13,7 @@ require("bufferline").setup({
             local name = buf.name
             local len = name ~= nil and string.len(name) or 0
             if len > MAX_NAME_LENGTH then
-                local half =
-                    math.floor(vim.fn.max({ (MAX_NAME_LENGTH - 1) / 2, 1 }))
+                local half = math.floor(MAX_NAME_LENGTH / 2) - 1
                 local left = string.sub(name, 1, half)
                 local right = string.sub(name, len - half, len)
                 name = left .. "…" .. right

--- a/lua/repo/akinsho/bufferline-nvim/config.lua
+++ b/lua/repo/akinsho/bufferline-nvim/config.lua
@@ -17,7 +17,7 @@ require("bufferline").setup({
                     math.floor(vim.fn.max({ (MAX_NAME_LENGTH - 1) / 2, 1 }))
                 local left = string.sub(name, 1, half)
                 local right = string.sub(name, len - half, len)
-                name = left .. "┄" .. right
+                name = left .. "…" .. right
             end
             return name
         end,

--- a/lua/repo/ibhagwan/fzf-lua/config.lua
+++ b/lua/repo/ibhagwan/fzf-lua/config.lua
@@ -1,14 +1,17 @@
 local const = require("cfg.const")
 local fzf_actions = require("fzf-lua.actions")
 local fzf_const = require("repo.ibhagwan.fzf-lua.const")
+local BAT_PREVIEW = not const.os.is_windows
+    and vim.fn.executable("bat") > 0
+    and vim.fn.executable("less") > 0
 
 require("fzf-lua").setup({
     winopts = {
-        height = 0.8,
+        height = 0.85,
         width = 0.9,
         border = const.ui.border,
         preview = {
-            default = "bat",
+            default = BAT_PREVIEW and "bat" or "builtin",
             border = const.ui.border,
             horizontal = "right:45%",
         },
@@ -70,16 +73,13 @@ require("fzf-lua").setup({
             args = "--style=numbers,changes,header --color always",
             theme = "ansi",
         },
-        builtin = {
-            treesitter = { enable = false },
-        },
     },
     manpages = { previewer = "man_native" },
     helptags = { previewer = "help_native" },
-    tags = { previewer = "bat" },
-    btags = { previewer = "bat" },
+    tags = { previewer = BAT_PREVIEW and "bat" or "builtin" },
+    btags = { previewer = BAT_PREVIEW and "bat" or "builtin" },
     files = {
-        previewer = "bat",
+        previewer = BAT_PREVIEW and "bat" or "builtin",
         cmd = fzf_const.FILES_CMD,
     },
     grep = {

--- a/lua/repo/ibhagwan/fzf-lua/config.lua
+++ b/lua/repo/ibhagwan/fzf-lua/config.lua
@@ -1,9 +1,7 @@
 local const = require("cfg.const")
 local fzf_actions = require("fzf-lua.actions")
 local fzf_const = require("repo.ibhagwan.fzf-lua.const")
-local BAT_PREVIEW = not const.os.is_windows
-    and vim.fn.executable("bat") > 0
-    and vim.fn.executable("less") > 0
+local BAT_PREVIEW = not const.os.is_windows and vim.fn.executable("bat") > 0
 
 require("fzf-lua").setup({
     winopts = {

--- a/lua/repo/ibhagwan/fzf-lua/config.lua
+++ b/lua/repo/ibhagwan/fzf-lua/config.lua
@@ -72,10 +72,6 @@ require("fzf-lua").setup({
             theme = "ansi",
         },
     },
-    manpages = { previewer = "man_native" },
-    helptags = { previewer = "help_native" },
-    tags = { previewer = BAT_PREVIEW and "bat" or "builtin" },
-    btags = { previewer = BAT_PREVIEW and "bat" or "builtin" },
     files = {
         previewer = BAT_PREVIEW and "bat" or "builtin",
         cmd = fzf_const.FILES_CMD,

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -24,20 +24,41 @@ local M = {
     -- search buffer
     keymap.map_lazy(
         "n",
-        "<space>bf",
+        "<space>b",
         keymap.exec(function()
             require("fzf-lua").buffers()
         end),
         { desc = "Search buffers (FzfLua)" }
     ),
     -- live grep
+    -- keymap.map_lazy(
+    --     "n",
+    --     "<space>l",
+    --     keymap.exec(function()
+    --         require("fzf-lua").live_grep()
+    --     end),
+    --     { desc = "Live grep (FzfLua)" }
+    -- ),
+    -- keymap.map_lazy(
+    --     "n",
+    --     "<space>ul",
+    --     keymap.exec(function()
+    --         require("fzf-lua").live_grep({
+    --             cmd = fzf_const.GREP_CMD .. " -uu", -- --unrestricted --hidden
+    --         })
+    --     end),
+    --     { desc = "Unrestricted live grep (FzfLua)" }
+    -- ),
     keymap.map_lazy(
         "n",
         "<space>l",
         keymap.exec(function()
-            require("fzf-lua").live_grep()
+            require("fzf-lua").live_grep({
+                cmd = fzf_const.GREP_CMD,
+                rg_glob = true,
+            })
         end),
-        { desc = "Live grep (FzfLua)" }
+        { desc = "Live grep with glob support via '--' (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -45,31 +66,10 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD .. " -uu", -- --unrestricted --hidden
-            })
-        end),
-        { desc = "Unrestricted live grep (FzfLua)" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>gl",
-        keymap.exec(function()
-            require("fzf-lua").live_grep({
-                cmd = fzf_const.GREP_CMD,
                 rg_glob = true,
             })
         end),
-        { desc = "Live grep with '--' glob (FzfLua)" }
-    ),
-    keymap.map_lazy(
-        "n",
-        "<space>ugl",
-        keymap.exec(function()
-            require("fzf-lua").live_grep({
-                cmd = fzf_const.GREP_CMD .. " -uu",
-                rg_glob = true,
-            })
-        end),
-        { desc = "Unrestricted live grep with '--' glob (FzfLua)" }
+        { desc = "Unrestricted live grep with glob support via '--' (FzfLua)" }
     ),
     -- search word
     keymap.map_lazy(

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -31,24 +31,6 @@ local M = {
         { desc = "Search buffers (FzfLua)" }
     ),
     -- live grep
-    -- keymap.map_lazy(
-    --     "n",
-    --     "<space>l",
-    --     keymap.exec(function()
-    --         require("fzf-lua").live_grep()
-    --     end),
-    --     { desc = "Live grep (FzfLua)" }
-    -- ),
-    -- keymap.map_lazy(
-    --     "n",
-    --     "<space>ul",
-    --     keymap.exec(function()
-    --         require("fzf-lua").live_grep({
-    --             cmd = fzf_const.GREP_CMD .. " -uu", -- --unrestricted --hidden
-    --         })
-    --     end),
-    --     { desc = "Unrestricted live grep (FzfLua)" }
-    -- ),
     keymap.map_lazy(
         "n",
         "<space>l",
@@ -70,6 +52,24 @@ local M = {
             })
         end),
         { desc = "Unrestricted live grep with glob support via '--' (FzfLua)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>nl",
+        keymap.exec(function()
+            require("fzf-lua").live_grep()
+        end),
+        { desc = "Live grep without glob support (FzfLua)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>unl",
+        keymap.exec(function()
+            require("fzf-lua").live_grep({
+                cmd = fzf_const.GREP_CMD .. " -uu", -- --unrestricted --hidden
+            })
+        end),
+        { desc = "Unrestricted live grep without glob support (FzfLua)" }
     ),
     -- search word
     keymap.map_lazy(

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -58,7 +58,7 @@ local M = {
                 rg_glob = true,
             })
         end),
-        { desc = "Live grep with glob '--'(FzfLua)" }
+        { desc = "Live grep with '--' glob(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -69,7 +69,7 @@ local M = {
                 rg_glob = true,
             })
         end),
-        { desc = "Unrestricted live grep with glob '--'(FzfLua)" }
+        { desc = "Unrestricted live grep with '--' glob(FzfLua)" }
     ),
     -- search word
     keymap.map_lazy(

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -9,7 +9,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").files()
         end),
-        { desc = "Search files(FzfLua)" }
+        { desc = "Search files (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -19,7 +19,7 @@ local M = {
                 cmd = fzf_const.FILES_CMD .. " -u", -- --unrestricted
             })
         end),
-        { desc = "Unrestricted search files(FzfLua)" }
+        { desc = "Unrestricted search files (FzfLua)" }
     ),
     -- search buffer
     keymap.map_lazy(
@@ -28,7 +28,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").buffers()
         end),
-        { desc = "Search buffers(FzfLua)" }
+        { desc = "Search buffers (FzfLua)" }
     ),
     -- live grep
     keymap.map_lazy(
@@ -37,7 +37,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").live_grep()
         end),
-        { desc = "Live grep(FzfLua)" }
+        { desc = "Live grep (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -47,7 +47,7 @@ local M = {
                 cmd = fzf_const.GREP_CMD .. " -uu", -- --unrestricted --hidden
             })
         end),
-        { desc = "Unrestricted live grep(FzfLua)" }
+        { desc = "Unrestricted live grep (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -58,7 +58,7 @@ local M = {
                 rg_glob = true,
             })
         end),
-        { desc = "Live grep with '--' glob(FzfLua)" }
+        { desc = "Live grep with '--' glob (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -69,7 +69,7 @@ local M = {
                 rg_glob = true,
             })
         end),
-        { desc = "Unrestricted live grep with '--' glob(FzfLua)" }
+        { desc = "Unrestricted live grep with '--' glob (FzfLua)" }
     ),
     -- search word
     keymap.map_lazy(
@@ -78,7 +78,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").grep_cword()
         end),
-        { desc = "Search word under cursor(FzfLua)" }
+        { desc = "Search word under cursor (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -88,7 +88,7 @@ local M = {
                 cmd = fzf_const.GREP_CMD .. " -uu",
             })
         end),
-        { desc = "Unrestricted search word under cursor(FzfLua)" }
+        { desc = "Unrestricted search word under cursor (FzfLua)" }
     ),
     -- search WORD
     keymap.map_lazy(
@@ -97,7 +97,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").grep_cWORD()
         end),
-        { desc = "Search WORD under cursor(FzfLua)" }
+        { desc = "Search WORD under cursor (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -107,7 +107,7 @@ local M = {
                 cmd = fzf_const.GREP_CMD .. " -uu",
             })
         end),
-        { desc = "Unrestricted search WORD under cursor(FzfLua)" }
+        { desc = "Unrestricted search WORD under cursor (FzfLua)" }
     ),
     -- search git
     keymap.map_lazy(
@@ -116,7 +116,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").git_commits()
         end),
-        { desc = "Search git commits(FzfLua)" }
+        { desc = "Search git commits (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -124,7 +124,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").git_files()
         end),
-        { desc = "Search git files(FzfLua)" }
+        { desc = "Search git files (FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
@@ -132,7 +132,7 @@ local M = {
         keymap.exec(function()
             require("fzf-lua").git_status()
         end),
-        { desc = "Search git status(FzfLua)" }
+        { desc = "Search git status (FzfLua)" }
     ),
 }
 

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -21,6 +21,15 @@ local M = {
         end),
         { desc = "Unrestricted search files(FzfLua)" }
     ),
+    -- search buffer
+    keymap.map_lazy(
+        "n",
+        "<space>b",
+        keymap.exec(function()
+            require("fzf-lua").buffers()
+        end),
+        { desc = "Search buffers(FzfLua)" }
+    ),
     -- live grep
     keymap.map_lazy(
         "n",
@@ -42,25 +51,25 @@ local M = {
     ),
     keymap.map_lazy(
         "n",
-        "<space>gl",
+        "<space>g",
         keymap.exec(function()
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD,
                 rg_glob = true,
             })
         end),
-        { desc = "Glob live grep(FzfLua)" }
+        { desc = "Live grep with glob '--'(FzfLua)" }
     ),
     keymap.map_lazy(
         "n",
-        "<space>ugl",
+        "<space>ug",
         keymap.exec(function()
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD .. " -uu",
                 rg_glob = true,
             })
         end),
-        { desc = "Unrestricted glob live grep(FzfLua)" }
+        { desc = "Unrestricted live grep with glob '--'(FzfLua)" }
     ),
     -- search word
     keymap.map_lazy(

--- a/lua/repo/ibhagwan/fzf-lua/keys.lua
+++ b/lua/repo/ibhagwan/fzf-lua/keys.lua
@@ -24,7 +24,7 @@ local M = {
     -- search buffer
     keymap.map_lazy(
         "n",
-        "<space>b",
+        "<space>bf",
         keymap.exec(function()
             require("fzf-lua").buffers()
         end),
@@ -51,7 +51,7 @@ local M = {
     ),
     keymap.map_lazy(
         "n",
-        "<space>g",
+        "<space>gl",
         keymap.exec(function()
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD,
@@ -62,7 +62,7 @@ local M = {
     ),
     keymap.map_lazy(
         "n",
-        "<space>ug",
+        "<space>ugl",
         keymap.exec(function()
             require("fzf-lua").live_grep({
                 cmd = fzf_const.GREP_CMD .. " -uu",
@@ -108,6 +108,31 @@ local M = {
             })
         end),
         { desc = "Unrestricted search WORD under cursor(FzfLua)" }
+    ),
+    -- search git
+    keymap.map_lazy(
+        "n",
+        "<space>gc",
+        keymap.exec(function()
+            require("fzf-lua").git_commits()
+        end),
+        { desc = "Search git commits(FzfLua)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>gf",
+        keymap.exec(function()
+            require("fzf-lua").git_files()
+        end),
+        { desc = "Search git files(FzfLua)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>gs",
+        keymap.exec(function()
+            require("fzf-lua").git_status()
+        end),
+        { desc = "Search git status(FzfLua)" }
     ),
 }
 

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -17,7 +17,7 @@ local M = {
     -- search buffer
     keymap.map_lazy(
         "n",
-        "<space>bf",
+        "<space>b",
         keymap.exec("FzfBuffers"),
         { desc = "Search buffers (Fzf)" }
     ),

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -6,65 +6,65 @@ local M = {
         "n",
         "<space>f",
         keymap.exec("FzfFiles"),
-        { desc = "Search files(Fzf)" }
+        { desc = "Search files (Fzf)" }
     ),
     keymap.map_lazy(
         "n",
         "<space>uf",
         keymap.exec("FzfUnrestrictedFiles"),
-        { desc = "Unrestricted search files(Fzf)" }
+        { desc = "Unrestricted search files (Fzf)" }
     ),
     -- search buffer
     keymap.map_lazy(
         "n",
         "<space>bf",
         keymap.exec("FzfBuffers"),
-        { desc = "Search buffers(Fzf)" }
+        { desc = "Search buffers (Fzf)" }
     ),
     -- live grep
     keymap.map_lazy(
         "n",
         "<space>l",
         keymap.exec("FzfLiveGrep"),
-        { desc = "Live grep(Fzf)" }
+        { desc = "Live grep (Fzf)" }
     ),
     keymap.map_lazy(
         "n",
         "<space>ul",
         keymap.exec("FzfUnrestrictedLiveGrep"),
-        { desc = "Unrestricted live grep(Fzf)" }
+        { desc = "Unrestricted live grep (Fzf)" }
     ),
     -- search word
     keymap.map_lazy(
         "n",
         "<space>w",
         keymap.exec("FzfCWord"),
-        { desc = "Search word under cursor(Fzf)" }
+        { desc = "Search word under cursor (Fzf)" }
     ),
     keymap.map_lazy(
         "n",
         "<space>uw",
         keymap.exec("FzfUnrestrictedCWord"),
-        { desc = "Unrestricted search word under cursor(Fzf)" }
+        { desc = "Unrestricted search word under cursor (Fzf)" }
     ),
     -- search git
     keymap.map_lazy(
         "n",
         "<space>gc",
         keymap.exec("FzfCommits"),
-        { desc = "Search git commits(Fzf)" }
+        { desc = "Search git commits (Fzf)" }
     ),
     keymap.map_lazy(
         "n",
         "<space>gf",
         keymap.exec("FzfGFiles"),
-        { desc = "Search git files(Fzf)" }
+        { desc = "Search git files (Fzf)" }
     ),
     keymap.map_lazy(
         "n",
         "<space>gs",
         keymap.exec("FzfGFiles?"),
-        { desc = "Search git status(Fzf)" }
+        { desc = "Search git status (Fzf)" }
     ),
 }
 

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -17,7 +17,7 @@ local M = {
     -- search buffer
     keymap.map_lazy(
         "n",
-        "<space>b",
+        "<space>bf",
         keymap.exec("FzfBuffers"),
         { desc = "Search buffers(Fzf)" }
     ),
@@ -46,6 +46,25 @@ local M = {
         "<space>uw",
         keymap.exec("FzfUnrestrictedCWord"),
         { desc = "Unrestricted search word under cursor(Fzf)" }
+    ),
+    -- search git
+    keymap.map_lazy(
+        "n",
+        "<space>gc",
+        keymap.exec("FzfCommits"),
+        { desc = "Search git commits(Fzf)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>gf",
+        keymap.exec("FzfGFiles"),
+        { desc = "Search git files(Fzf)" }
+    ),
+    keymap.map_lazy(
+        "n",
+        "<space>gs",
+        keymap.exec("FzfGFiles?"),
+        { desc = "Search git status(Fzf)" }
     ),
 }
 

--- a/lua/repo/junegunn/fzf-vim/keys.lua
+++ b/lua/repo/junegunn/fzf-vim/keys.lua
@@ -12,7 +12,14 @@ local M = {
         "n",
         "<space>uf",
         keymap.exec("FzfUnrestrictedFiles"),
-        { desc = "Search files unrestrictedly(Fzf)" }
+        { desc = "Unrestricted search files(Fzf)" }
+    ),
+    -- search buffer
+    keymap.map_lazy(
+        "n",
+        "<space>b",
+        keymap.exec("FzfBuffers"),
+        { desc = "Search buffers(Fzf)" }
     ),
     -- live grep
     keymap.map_lazy(

--- a/lua/repo/nvim-telescope/telescope-nvim/config.lua
+++ b/lua/repo/nvim-telescope/telescope-nvim/config.lua
@@ -1,7 +1,7 @@
 local const = require("cfg.const")
-local IS_WIN = const.os.is_windows
-local NO_BAT = vim.fn.executable("bat") <= 0
-local NO_LESS = vim.fn.executable("less") <= 0
+local BAT_PREVIEW = not const.os.is_windows
+    and vim.fn.executable("bat") > 0
+    and vim.fn.executable("less") > 0
 
 require("telescope").setup({
     defaults = {
@@ -66,12 +66,12 @@ require("telescope").setup({
                 ["<M-q>"] = false, --actions.send_selected_to_qflist + actions.open_qflist,,
             },
         },
-        file_previewer = (IS_WIN or NO_BAT or NO_LESS) and require(
-            "telescope.previewers"
-        ).vim_buffer_cat.new or require("telescope.previewers").cat.new,
-        grep_previewer = (IS_WIN or NO_BAT or NO_LESS) and require(
-            "telescope.previewers"
-        ).vim_buffer_vimgrep.new or require("telescope.previewers").vimgrep.new,
+        file_previewer = BAT_PREVIEW
+                and require("telescope.previewers").cat.new
+            or require("telescope.previewers").vim_buffer_cat.new,
+        grep_previewer = BAT_PREVIEW
+                and require("telescope.previewers").vimgrep.new
+            or require("telescope.previewers").vim_buffer_vimgrep.new,
     },
     extensions = {
         fzf = {

--- a/repo/junegunn/fzf.vim/init.vim
+++ b/repo/junegunn/fzf.vim/init.vim
@@ -15,7 +15,7 @@ let $BAT_THEME='ansi'
 let $BAT_STYLE='numbers,changes,header'
 
 " ui
-let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.8 } }
+let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.85 } }
 let g:fzf_preview_window = ['right,45%', 'ctrl-l']
 
 " command prefix


### PR DESCRIPTION
1. add fzf back.
    * Telescope can be used on both *nix and windows, especially support `rg --iglob`. Fzf-lua for now cannot support windows, while fzf.vim cannot support `rg --iglob` (maybe there's a way, but I never make it work).
    * Fzf is much more performant(fluent and smooth) than telescope.
2. remove ctrl+? keys in fzf.
3. add undotree back in user plugins sample.