### PR TITLE
plugin: move some plugins from sample list back to embed

### DIFF
--- a/lua/cfg/plugins.lua
+++ b/lua/cfg/plugins.lua
@@ -587,6 +587,29 @@ local M = {
         event = { VeryLazy, BufRead, BufNewFile },
         config = lua_config("kylechui/nvim-surround"),
     },
+    -- Structure outlines based on tags
+    {
+        "liuchengxu/vista.vim",
+        cmd = { "Vista" },
+        dependencies = { "ludovicchabant/vim-gutentags" },
+        init = lua_init("liuchengxu/vista.vim"),
+        keys = lua_keys("liuchengxu/vista.vim"),
+    },
+    -- Url viewer
+    {
+        "axieax/urlview.nvim",
+        cmd = { "UrlView" },
+        config = lua_config("axieax/urlview.nvim"),
+        keys = lua_keys("axieax/urlview.nvim"),
+    },
+    -- Terminal
+    {
+        "akinsho/toggleterm.nvim",
+        version = "*",
+        event = { VeryLazy, CmdlineEnter },
+        config = lua_config("akinsho/toggleterm.nvim"),
+        keys = lua_keys("akinsho/toggleterm.nvim"),
+    },
 }
 
 -- Check if `user_plugins` exist

--- a/lua/cfg/user_plugins_sample.lua
+++ b/lua/cfg/user_plugins_sample.lua
@@ -39,7 +39,7 @@ local VimEnter = "VimEnter"
 local InsertEnter = "InsertEnter"
 
 return {
-    -- github copilot
+    -- Copilot
     {
         "zbirenbaum/copilot-cmp",
         event = { VeryLazy, InsertEnter, CmdlineEnter },
@@ -50,38 +50,10 @@ return {
         event = { VeryLazy, InsertEnter, CmdlineEnter },
         config = lua_config("zbirenbaum/copilot.lua"),
     },
-    -- tags
+    -- Cmp tags source
     {
         "quangnguyen30192/cmp-nvim-tags",
         event = { VeryLazy, InsertEnter, CmdlineEnter },
-    },
-    -- structure outlines based on tags
-    {
-        "liuchengxu/vista.vim",
-        cmd = { "Vista" },
-        dependencies = { "ludovicchabant/vim-gutentags" },
-        keys = lua_keys("liuchengxu/vista.vim"),
-    },
-    -- buffer manager
-    {
-        "j-morano/buffer_manager.nvim",
-        config = lua_config("j-morano/buffer_manager.nvim"),
-        keys = lua_keys("j-morano/buffer_manager.nvim"),
-    },
-    -- url viewer
-    {
-        "axieax/urlview.nvim",
-        cmd = { "UrlView" },
-        config = lua_config("axieax/urlview.nvim"),
-        keys = lua_keys("axieax/urlview.nvim"),
-    },
-    -- terminal
-    {
-        "akinsho/toggleterm.nvim",
-        version = "*",
-        event = { VeryLazy, CmdlineEnter },
-        config = lua_config("akinsho/toggleterm.nvim"),
-        keys = lua_keys("akinsho/toggleterm.nvim"),
     },
     -- Generate documents
     {
@@ -92,5 +64,17 @@ return {
             or ":call doge#install()",
         init = vim_init("kkoomen/vim-doge"),
         keys = lua_keys("kkoomen/vim-doge"),
+    },
+    -- Undo tree
+    {
+        "mbbill/undotree",
+        event = { VeryLazy, CmdlineEnter },
+        keys = lua_keys("mbbill/undotree"),
+    },
+    -- Buffer manager
+    {
+        "j-morano/buffer_manager.nvim",
+        config = lua_config("j-morano/buffer_manager.nvim"),
+        keys = lua_keys("j-morano/buffer_manager.nvim"),
     },
 }

--- a/lua/repo/liuchengxu/vista-vim/init.lua
+++ b/lua/repo/liuchengxu/vista-vim/init.lua
@@ -1,0 +1,3 @@
+local editor_width = require("cfg.ui").editor_width
+
+vim.g.vista_sidebar_width = editor_width(0.2, 20, 40)

--- a/lua/repo/mbbill/undotree/init.lua
+++ b/lua/repo/mbbill/undotree/init.lua
@@ -1,0 +1,5 @@
+local editor_width = require("cfg.ui").editor_width
+local editor_height = require("cfg.ui").editor_height
+
+vim.g.undotree_SplitWidth = editor_width(0.2, 20, 40)
+vim.g.undotree_DiffpanelHeight = editor_height(0.4, 10, 40)

--- a/lua/repo/mbbill/undotree/keys.lua
+++ b/lua/repo/mbbill/undotree/keys.lua
@@ -3,7 +3,7 @@ local map_lazy = require("cfg.keymap").map_lazy
 local M = {
     map_lazy(
         "n",
-        "<leader>ut",
+        "<leader>ud",
         ":UndotreeToggle<CR>",
         { silent = false, desc = "Toggle undo tree" }
     ),

--- a/lua/repo/nvim-telescope/telescope-nvim/config.lua
+++ b/lua/repo/nvim-telescope/telescope-nvim/config.lua
@@ -73,10 +73,24 @@ require("telescope").setup({
                 and require("telescope.previewers").vimgrep.new
             or require("telescope.previewers").vim_buffer_vimgrep.new,
     },
+    pickers = {
+        buffers = {
+            -- close buffer key mappings
+            mappings = {
+                n = {
+                    ["<C-x>"] = require("telescope.actions").delete_buffer,
+                    ["dd"] = require("telescope.actions").delete_buffer,
+                },
+                i = {
+                    ["<C-x>"] = require("telescope.actions").delete_buffer,
+                },
+            },
+        },
+    },
     extensions = {
         fzf = {
             fuzzy = true,
-            override_generic_sorter = true, -- don't fuzzy on live_grep/grep_string
+            override_generic_sorter = true,
             override_file_sorter = true,
             case_mode = "ignore_case",
         },
@@ -91,7 +105,6 @@ require("telescope").setup({
                 },
             },
         },
-        undo = {},
     },
 })
 


### PR DESCRIPTION
1. move vista,urlview,toggleterm back to embed plugins.
2. optimize vista,undotree layout.
3. change undotree keys from `<leader>ut` to <leader>ud`, to keep compatible with telescope-undo's `<space>ud`.
4. add `<C-x>` and `dd` (only in normal mode) in telescope buffers picker to delete buffer.