### PR TITLE
remap: use `\gd` instead of `\dg` for doge-generate

### DIFF
--- a/lua/repo/kkoomen/vim-doge/keys.lua
+++ b/lua/repo/kkoomen/vim-doge/keys.lua
@@ -3,7 +3,7 @@ local map_lazy = require("cfg.keymap").map_lazy
 local M = {
     map_lazy(
         "n",
-        "<leader>dg",
+        "<leader>gd",
         ":DogeGenerate ",
         { desc = "Generate document" }
     ),


### PR DESCRIPTION
1. remap: use `\gd` instead of `\dg` for doge-generate