### PR TITLE
feat(nvim-lint): migrate 'none-ls.nvim' to 'nvim-lint'

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -191,13 +191,13 @@ function NvimConfig()
         Copy-Item -Path "$ConformHome\formatters_by_ft_sample.lua" -Destination "$ConformFormattersByFt"
     }
 
-    # # nvim-lint
-    # $NvimLintHome="$NVIM_HOME\lua\configs\mfussenegger\nvim-lint"
-    # $NvimLintLintersByFt="$NvimLintHome\linters_by_ft.lua"
-    # if (-not(TestReparsePoint $NvimLintLintersByFt) -and -not(Test-Path $NvimLintLintersByFt))
-    # {
-    #     Copy-Item -Path "$NvimLintHome\linters_by_ft_sample.lua" -Destination "$NvimLintLintersByFt"
-    # }
+    # nvim-lint
+    $NvimLintHome="$NVIM_HOME\lua\configs\mfussenegger\nvim-lint"
+    $NvimLintLintersByFt="$NvimLintHome\linters_by_ft.lua"
+    if (-not(TestReparsePoint $NvimLintLintersByFt) -and -not(Test-Path $NvimLintLintersByFt))
+    {
+        Copy-Item -Path "$NvimLintHome\linters_by_ft_sample.lua" -Destination "$NvimLintLintersByFt"
+    }
 }
 
 Info "install for Windows"

--- a/install.sh
+++ b/install.sh
@@ -435,12 +435,12 @@ nvim_config() {
         cp $conform_home/formatters_by_ft_sample.lua $conform_formatters_by_ft
     fi
 
-    # # nvim-lint
-    # local nvim_lint_home="$NVIM_HOME/lua/configs/mfussenegger/nvim-lint"
-    # local nvim_lint_linters_by_ft="$nvim_lint_home/linters_by_ft.lua"
-    # if [ ! -f $nvim_lint_linters_by_ft ]; then
-    #     cp $nvim_lint_home/linters_by_ft_sample.lua $nvim_lint_linters_by_ft
-    # fi
+    # nvim-lint
+    local nvim_lint_home="$NVIM_HOME/lua/configs/mfussenegger/nvim-lint"
+    local nvim_lint_linters_by_ft="$nvim_lint_home/linters_by_ft.lua"
+    if [ ! -f $nvim_lint_linters_by_ft ]; then
+        cp $nvim_lint_home/linters_by_ft_sample.lua $nvim_lint_linters_by_ft
+    fi
 }
 
 info "install for $OS"

--- a/lua/configs/mfussenegger/nvim-lint/linters_by_ft_sample.lua
+++ b/lua/configs/mfussenegger/nvim-lint/linters_by_ft_sample.lua
@@ -2,16 +2,14 @@
 
 -- Configure linters by filetypes.
 
-local eslint = { "eslint_d", "eslint" }
-
 local linters_by_ft = {
-    -- lua = { "selene", "luacheck" },
-    -- markdown = { "markdownlint" },
-    -- python = { "ruff", "mypy", "pylint" },
-    -- javascript = { eslint },
-    -- javascriptreact = { eslint },
-    -- typescript = { eslint },
-    -- typescriptreact = { eslint },
+    lua = { "selene", "luacheck" },
+    markdown = { "markdownlint" },
+    python = { "ruff", "mypy", "pylint" },
+    javascript = { "biome", "eslint_d", "eslint" },
+    javascriptreact = { "biome", "eslint_d", "eslint" },
+    typescript = { "biome", "eslint_d", "eslint" },
+    typescriptreact = { "biome", "eslint_d", "eslint" },
 }
 
 return linters_by_ft

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -269,7 +269,7 @@ local M = {
     },
     {
         "stevearc/conform.nvim",
-        event = { BufWritePost },
+        event = { VeryLazy, BufWritePost },
         cmd = { "ConformInfo" },
         dependencies = {
             "neovim/nvim-lspconfig",
@@ -279,15 +279,25 @@ local M = {
         config = lua_config("stevearc/conform.nvim"),
         keys = lua_keys("stevearc/conform.nvim"),
     },
+    -- {
+    --     "nvimtools/none-ls.nvim",
+    --     event = { VeryLazy },
+    --     cmd = {
+    --         "NullLsInfo",
+    --         "NullLsLog",
+    --     },
+    --     dependencies = { "neovim/nvim-lspconfig" },
+    --     config = lua_config("jose-elias-alvarez/null-ls.nvim"),
+    -- },
     {
-        "nvimtools/none-ls.nvim",
-        event = { VeryLazy },
-        cmd = {
-            "NullLsInfo",
-            "NullLsLog",
+        "mfussenegger/nvim-lint",
+        event = { VeryLazy, BufWritePost },
+        dependencies = {
+            "neovim/nvim-lspconfig",
+            "williamboman/mason.nvim",
+            "williamboman/mason-lspconfig.nvim",
         },
-        dependencies = { "neovim/nvim-lspconfig" },
-        config = lua_config("jose-elias-alvarez/null-ls.nvim"),
+        config = lua_config("mfussenegger/nvim-lint"),
     },
     {
         "jay-babu/mason-null-ls.nvim",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -289,6 +289,23 @@ local M = {
     --     dependencies = { "neovim/nvim-lspconfig" },
     --     config = lua_config("jose-elias-alvarez/null-ls.nvim"),
     -- },
+    -- {
+    --     "jay-babu/mason-null-ls.nvim",
+    --     event = { VeryLazy },
+    --     cmd = {
+    --         "NullLsInstall",
+    --         "NoneLsInstall",
+    --         "NullLsUninstall",
+    --         "NoneLsUninstall",
+    --     },
+    --     dependencies = {
+    --         "neovim/nvim-lspconfig",
+    --         "williamboman/mason.nvim",
+    --         "williamboman/mason-lspconfig.nvim",
+    --         "nvimtools/none-ls.nvim",
+    --     },
+    --     config = lua_config("jay-babu/mason-null-ls.nvim"),
+    -- },
     {
         "mfussenegger/nvim-lint",
         event = { VeryLazy, BufWritePost },
@@ -298,23 +315,6 @@ local M = {
             "williamboman/mason-lspconfig.nvim",
         },
         config = lua_config("mfussenegger/nvim-lint"),
-    },
-    {
-        "jay-babu/mason-null-ls.nvim",
-        event = { VeryLazy },
-        cmd = {
-            "NullLsInstall",
-            "NoneLsInstall",
-            "NullLsUninstall",
-            "NoneLsUninstall",
-        },
-        dependencies = {
-            "neovim/nvim-lspconfig",
-            "williamboman/mason.nvim",
-            "williamboman/mason-lspconfig.nvim",
-            "nvimtools/none-ls.nvim",
-        },
-        config = lua_config("jay-babu/mason-null-ls.nvim"),
     },
     -- Json schema
     {


### PR DESCRIPTION
none-ls.nvim had deprecated luacheck and some other tools, which is not compatible with the philosophy of my config: tools should not be deprecated only because it's over mature or there's a new promising replacement.

It's true that 'selene' (a rust-rewritten lua static checker) is and should be much better than 'luacheck', but the ladder is still widely used in community, and maintained, not dead.