### PR TITLE
perf(heirline.nvim): async query git branch name, remove calling 'git-prompt-string'

### DIFF
--- a/lua/configs/rebelot/heirline-nvim/config.lua
+++ b/lua/configs/rebelot/heirline-nvim/config.lua
@@ -1132,7 +1132,7 @@ if vim.fn.executable("git-prompt-string") > 0 then
   end
 
   vim.api.nvim_create_autocmd(
-    { "FocusGained", "TermLeave", "TermClose", "BufEnter", "CursorHold", "CursorMoved" },
+    { "FocusGained", "TermLeave", "TermClose", "BufEnter", "CursorHold" },
     {
       group = "heirline_augroup",
       callback = update_git_branch_info,
@@ -1185,7 +1185,7 @@ if vim.fn.executable("git") > 0 then
   end
 
   vim.api.nvim_create_autocmd(
-    { "FocusGained", "TermLeave", "TermClose", "BufEnter", "CursorHold", "CursorMoved" },
+    { "FocusGained", "TermLeave", "TermClose", "BufEnter", "CursorHold" },
     {
       group = "heirline_augroup",
       callback = update_git_branch_name,

--- a/lua/configs/rebelot/heirline-nvim/config.lua
+++ b/lua/configs/rebelot/heirline-nvim/config.lua
@@ -1095,9 +1095,6 @@ if vim.fn.executable("git-prompt-string") > 0 then
         failed_get_branch = true
       end,
     }, function()
-      print(
-        string.format("failed:%s, branch:%s", vim.inspect(failed_get_branch), vim.inspect(branch))
-      )
       if failed_get_branch then
         before_exit()
         return

--- a/lua/configs/rebelot/heirline-nvim/config.lua
+++ b/lua/configs/rebelot/heirline-nvim/config.lua
@@ -1094,8 +1094,8 @@ if vim.fn.executable("git-prompt-string") > 0 then
       on_stderr = function()
         failed_get_branch = true
       end,
-    }, function()
-      if failed_get_branch then
+    }, function(completed)
+      if failed_get_branch or tbl.tbl_get(completed, "code") ~= 0 then
         before_exit()
         return
       end
@@ -1119,8 +1119,12 @@ if vim.fn.executable("git-prompt-string") > 0 then
         on_stderr = function()
           failed_get_branch_info = true
         end,
-      }, function()
-        if not failed_get_branch_info and str.not_empty(branch_info) then
+      }, function(json_completed)
+        if
+          not failed_get_branch_info
+          and str.not_empty(branch_info)
+          and tbl.tbl_get(json_completed, "code") == 0
+        then
           local ok, j = pcall(vim.json.decode, branch_info)
           if ok and str.not_empty(tbl.tbl_get(j, "color")) then
             git_prompt_string_color_cache = j["color"]
@@ -1173,8 +1177,8 @@ if vim.fn.executable("git") > 0 then
       on_stderr = function()
         branch = nil
       end,
-    }, function()
-      if failed_get_branch then
+    }, function(completed)
+      if failed_get_branch or tbl.tbl_get(completed, "code") ~= 0 then
         before_exit()
         return
       end

--- a/lua/configs/rebelot/heirline-nvim/config.lua
+++ b/lua/configs/rebelot/heirline-nvim/config.lua
@@ -1044,7 +1044,7 @@ local function get_buffer_dir()
   return nil
 end
 
-local has_git_prompt_string = vim.fn.executable("git-prompt-string") > 0
+local HAS_GIT_PROMPT_STRING = vim.fn.executable("git-prompt-string") > 0
 local running_git_branch_info = false
 
 local function before_exit()
@@ -1085,7 +1085,7 @@ local function update_git_branch()
     end
 
     git_branch_name_cache = branch_name
-    if not has_git_prompt_string then
+    if not HAS_GIT_PROMPT_STRING then
       before_exit()
       return
     end

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -132,10 +132,6 @@ local M = {
   },
   -- Statusline
   {
-    "itchyny/vim-gitbranch",
-    event = { VeryLazy },
-  },
-  {
     "linrongbin16/lsp-progress.nvim",
     lazy = true,
     config = lua_config("linrongbin16/lsp-progress.nvim"),


### PR DESCRIPTION
Because 'git' command is much more stable than 'git-prompt-string', sometimes the ladder one will returns empty string in a valid git repository.