### PR TITLE
feat(outline.nvim): migrate "aerial.nvim" to "outline.nvim"

### DIFF
--- a/lua/configs/hedyhli/outline-nvim/config.lua
+++ b/lua/configs/hedyhli/outline-nvim/config.lua
@@ -1,0 +1,8 @@
+local constants = require("builtin.constants")
+local layout = require("builtin.utils.layout")
+
+require("outline").setup({
+  outline_window = {
+    width = constants.window.layout.sidebar.scale * 100,
+  },
+})

--- a/lua/configs/hedyhli/outline-nvim/keys.lua
+++ b/lua/configs/hedyhli/outline-nvim/keys.lua
@@ -1,0 +1,7 @@
+local set_lazy_key = require("builtin.utils.keymap").set_lazy_key
+
+local M = {
+  set_lazy_key("n", "<leader>ol", "<cmd>Outline<cr>", { desc = "Toggle outline" }),
+}
+
+return M

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -328,19 +328,16 @@ local M = {
   },
   -- Structure outlines
   {
-    "stevearc/aerial.nvim",
+    "hedyhli/outline.nvim",
     cmd = {
-      "AerialToggle",
-      "AerialOpen",
-      "AerialOpenAll",
-      "AerialClose",
-      "AerialInfo",
+      "Outline",
+      "OutlineOpen",
     },
     dependencies = {
       "neovim/nvim-lspconfig",
     },
-    keys = lua_keys("stevearc/aerial.nvim"),
-    config = lua_config("stevearc/aerial.nvim"),
+    keys = lua_keys("hedyhli/outline.nvim"),
+    config = lua_config("hedyhli/outline.nvim"),
   },
   -- Open Url
   {


### PR DESCRIPTION
This PR migrate the structure/symbols outline plugin from "aerial.nvim" to "outline.nvim".

Since #625 , this config dropped all the plugins that requires the "nvim-treesitter".

I found there's a freezing bug, that when writing rust code `[1,2,3].into_iter().collect::<Vec<usize>>()`, the last char `>` in the Vec template will freeze the nvim editor. The editor process CPU usage goes up to 100% and never stop.

After disable all the "nvim-treesitter" related plugins, this issue disappears.

I guess some treesitter plugins just keep querying the tokens and fall into a dead while loop. So I simply removed all the treesitter based plugins.