### PR TITLE
perf(glance.nvim): revert lsp goto back to 'glance' for shorter lantency

### DIFF
--- a/lua/configs/linrongbin16/fzfx-nvim/keys.lua
+++ b/lua/configs/linrongbin16/fzfx-nvim/keys.lua
@@ -55,19 +55,19 @@ local M = {
     "<cmd>FzfxLspDiagnostics visual<cr>",
     { desc = "Search lsp diagnostics" }
   ),
-  -- lsp
-  set_lazy_key("n", "gd", function()
-    vim.cmd("FzfxLspDefinitions")
-  end, { desc = "Go to LSP definition" }),
-  set_lazy_key("n", "gt", function()
-    vim.cmd("FzfxLspTypeDefinitions")
-  end, { desc = "Go to LSP type definition" }),
-  set_lazy_key("n", "gi", function()
-    vim.cmd("FzfxLspImplementations")
-  end, { desc = "Go to LSP implementation" }),
-  set_lazy_key("n", "gr", function()
-    vim.cmd("FzfxLspReferences")
-  end, { desc = "Go to LSP reference" }),
+  -- -- lsp
+  -- set_lazy_key("n", "gd", function()
+  --   vim.cmd("FzfxLspDefinitions")
+  -- end, { desc = "Go to LSP definition" }),
+  -- set_lazy_key("n", "gt", function()
+  --   vim.cmd("FzfxLspTypeDefinitions")
+  -- end, { desc = "Go to LSP type definition" }),
+  -- set_lazy_key("n", "gi", function()
+  --   vim.cmd("FzfxLspImplementations")
+  -- end, { desc = "Go to LSP implementation" }),
+  -- set_lazy_key("n", "gr", function()
+  --   vim.cmd("FzfxLspReferences")
+  -- end, { desc = "Go to LSP reference" }),
 }
 
 return M

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -231,18 +231,18 @@ local M = {
     },
     config = lua_config("jay-babu/mason-null-ls.nvim"),
   },
-  -- {
-  --   "DNLHC/glance.nvim",
-  --   cmd = { "Glance" },
-  --   dependencies = {
-  --     "neovim/nvim-lspconfig",
-  --     "mason-org/mason.nvim",
-  --     "mason-org/mason-lspconfig.nvim",
-  --     "nvimtools/none-ls.nvim",
-  --   },
-  --   config = lua_config("DNLHC/glance.nvim"),
-  --   keys = lua_keys("DNLHC/glance.nvim"),
-  -- },
+  {
+    "DNLHC/glance.nvim",
+    cmd = { "Glance" },
+    dependencies = {
+      "neovim/nvim-lspconfig",
+      "mason-org/mason.nvim",
+      "mason-org/mason-lspconfig.nvim",
+      "nvimtools/none-ls.nvim",
+    },
+    config = lua_config("DNLHC/glance.nvim"),
+    keys = lua_keys("DNLHC/glance.nvim"),
+  },
 
   -- ---- AUTO-COMPLETE ----
   {


### PR DESCRIPTION
Have no idea why goto commands (definition, type definition, implementation, reference) in 'fzfx.nvim' is still slower than 'glance.nvim', even I use the same API...